### PR TITLE
Feature/booksonic

### DIFF
--- a/community.yml
+++ b/community.yml
@@ -12,6 +12,7 @@
     - { role: bazarrx, tags: ['bazarrx'] }
     - { role: beets, tags: ['beets'] }
     - { role: bitwarden, tags: ['bitwarden'] }
+    - { role: booksonic, tags: ['booksonic']}
     - { role: bookstack, tags: ['bookstack'] }
     - { role: calibre-rdp, tags: ['calibre-rdp'] }
     - { role: calibre-rdp, tags: ['calibre-rdp'] }

--- a/roles/booksonic/tasks/main.yml
+++ b/roles/booksonic/tasks/main.yml
@@ -1,0 +1,45 @@
+- name: "Setting CloudFlare DNS Record"
+  include_role:
+    name: cloudflare
+  vars:
+    subdomain: booksonic
+
+- name: Stop and remove any existing container
+  docker_container:
+    name: booksonic
+    state: absent
+
+- name: Create booksonic directories
+  file: "path={{item}} state=directory mode=0775 owner={{user}} group={{user}}"
+  with_items:
+    - /opt/booksonic
+
+- name: Create and start container
+  docker_container:
+    name: booksonic
+    image: linuxserver/booksonic
+    pull: yes
+    published_ports:
+      - "127.0.0.1:4042:4040"
+    env:
+      PUID: "{{uid}}"
+      PGID: "{{gid}}"
+      VIRTUAL_HOST: "booksonic.{{domain}}"
+      VIRTUAL_PORT: 4040
+      LETSENCRYPT_HOST: "booksonic.{{domain}}"
+      LETSENCRYPT_EMAIL: "{{email}}"
+    volumes:
+      - "/etc/localtime:/etc/localtime:ro"
+      - "/opt/booksonic:/config"
+      - "/mnt/unionfs/Media/Audiobooks:/audiobooks"
+      - "/mnt/unionfs/Media/Podcasts:/podcasts"
+      - "/mnt/unionfs/Media:/media"
+    labels:
+      "com.github.cloudbox.cloudbox_managed": "true"
+    networks:
+      - name: cloudbox
+        aliases:
+          - booksonic
+    purge_networks: yes
+    restart_policy: always
+    state: started

--- a/roles/booksonic/tasks/main.yml
+++ b/roles/booksonic/tasks/main.yml
@@ -31,9 +31,9 @@
     volumes:
       - "/etc/localtime:/etc/localtime:ro"
       - "/opt/booksonic:/config"
-      - "/mnt/unionfs/Media/Audiobooks:/books"
+      - "/mnt/unionfs/Media/Audiobbooksooks:/"
       - "/mnt/unionfs/Media/Podcasts:/podcasts"
-      - "/mnt/unionfs/Media:/media"
+      - "/mnt/unionfs:/media"
     labels:
       "com.github.cloudbox.cloudbox_managed": "true"
     networks:

--- a/roles/booksonic/tasks/main.yml
+++ b/roles/booksonic/tasks/main.yml
@@ -31,7 +31,7 @@
     volumes:
       - "/etc/localtime:/etc/localtime:ro"
       - "/opt/booksonic:/config"
-      - "/mnt/unionfs/Media/Audiobooks:/audiobooks"
+      - "/mnt/unionfs/Media/Audiobooks:/books"
       - "/mnt/unionfs/Media/Podcasts:/podcasts"
       - "/mnt/unionfs/Media:/media"
     labels:


### PR DESCRIPTION
[Booksonic](http://booksonic.org/) is a fork of subsonic/airsonic for audiobooks and podcasts. I've set the internal port to 4042 so it doesn't conflict with Airsonic or Subsonic. I'm using Linuxserver's [container](https://hub.docker.com/r/linuxserver/booksonic/).

By default it wants /books and /podcasts. I set those as:

`"/mnt/unionfs/Media/Audiobooks:/books"
`
`"/mnt/unionfs/Media/Podcasts:/podcasts"
`

I also included `/mnt/unionfs:/media` so users can get to other places they might have been storing audiobooks. 