### PR TITLE
Radarr4k was unable to connect when built using the hotio image

### DIFF
--- a/roles/radarrx/tasks/template.yml
+++ b/roles/radarrx/tasks/template.yml
@@ -47,7 +47,7 @@
 - name: Create and start container
   docker_container:
     name: "radarr{{ rolename }}"
-    image: "hotio/radarr"
+    image: "andrewkhunn/radarr"
     pull: yes
     published_ports:
       - "127.0.0.1:{{ roleport }}:7878"


### PR DESCRIPTION
When building using the hotio/radarr image, something was causing Radarr4k to be inaccessible via the `radarr4k.yourdomain.com` _and_ directly via `<ip-address>:17878`. Replacing the image with andrewkhunn/radarr (which is the image used in the main Cloudbox repo) seems to have fixed the issue.