### PR TITLE
TransmissionVPN: Fix cloudflare vars error

### DIFF
--- a/roles/transmissionvpn/tasks/main.yml
+++ b/roles/transmissionvpn/tasks/main.yml
@@ -13,7 +13,7 @@
   include_role:
     name: cloudflare-dns
   vars:
-    subdomain: transmissionvpn
+    record: transmissionvpn
   when: cloudflare_enabled
 
 - name: Stop and remove any existing container


### PR DESCRIPTION
TransmissionVPN cloudflare vars was set to "subdomain" but should've been set to "record".