### PR TITLE
Add LazyMan IP addresses to container

### DIFF
--- a/roles/jellyfin/tasks/main.yml
+++ b/roles/jellyfin/tasks/main.yml
@@ -67,6 +67,13 @@
     path: "/dev/dri"
   register: dev_dri
 
+- name: "Get IP for LazyMan"
+  set_fact: lazyman_ip="{{ lookup('dig', 'nhl.freegamez.ga.', '@8.8.8.8', 'qtype=A') }}"
+
+- name: "Set custom hosts"
+  set_fact:
+    jellyfin_custom_hosts: { "playback.svcs.mlb.com": "{{ (lazyman_ip|ipv4) | ternary(lazyman_ip,'127.0.0.1') }}", "mf.svc.nhl.com": "{{ (lazyman_ip|ipv4) | ternary(lazyman_ip,'127.0.0.1') }}", "mlb-ws-mf.media.mlb.com": "{{ (lazyman_ip|ipv4) | ternary(lazyman_ip, '127.0.0.1') }}" }
+
 - name: Create and start container
   docker_container:
     name: jellyfin
@@ -93,6 +100,7 @@
     devices: "{{ '/dev/dri:/dev/dri' if (gpu.intel and dev_dri.stat.exists) | default(false) else omit }}"
     labels:
       "com.github.cloudbox.cloudbox_managed": "true"
+    etc_hosts: "{{ jellyfin_custom_hosts }}"
     networks:
       - name: cloudbox
         aliases:
@@ -116,7 +124,7 @@
 - name: Settings Tasks
   include_tasks: "jellyfin_settings.yml"
   when: not (
-        (jellyfin_system_xml.exists)
+        (jellyfin_system_xml.stat.exists)
         or
         (continuous_integration)
     )


### PR DESCRIPTION
Added lookup of current LazyMan IP address and addition to container's hosts file for the three domains used by LazyMan. See https://www.reddit.com/r/LazyMan/wiki/hostsfile for details. Based on previous code from Plex role.

LazyMan plugin for Jellyfin is available at https://github.com/crobibero/Jellyfin.Channels.LazyMan

Also fixed check of jellyfin_system_xml file in Settings Task.