### PR TITLE
Wireguard Role

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,6 +77,7 @@ environment:
     unifi
     unmanic
     watchtower
+    wireguard
     wordpress
     xteve
     znc

--- a/community.yml
+++ b/community.yml
@@ -78,6 +78,7 @@
     - { role: unifi, tags: ['unifi'] }
     - { role: unmanic, tags: ['unmanic'] }
     - { role: watchtower, tags: ['watchtower'] }
+    - { role: wireguard, tags: ['wireguard'] }
     - { role: wordpress, tags: ['wordpress'] }
     - { role: xteve, tags: ['xteve'] }
     - { role: znc, tags: ['znc'] }

--- a/roles/settings/tasks/main.yml
+++ b/roles/settings/tasks/main.yml
@@ -11,7 +11,6 @@
 - name: "Install ruamel.yaml"
   pip:
     name: ruamel.yaml
-    version: 0.15.35
     executable: pip3
 
 - name: "Get 'community.yml' info."

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+# defaults file for wireguard_role
+
+#Declare the VPN subnet
+vpn_network: '10.200.200'
+
+#Declare the VPN server port
+vpn_port: '51820'
+
+#Declare the number of clients
+clients: 10
+
+client_config_path: 'wireguard/profiles'

--- a/roles/wireguard/tasks/dns.yml
+++ b/roles/wireguard/tasks/dns.yml
@@ -1,0 +1,70 @@
+- name: Install unbound
+  apt: 
+    name:
+      - unbound
+      - unbound-host
+    state: present
+    update_cache: true
+
+- name: Download the list of root DNS servers
+  get_url:
+    url: https://www.internic.net/domain/named.cache
+    dest: /var/lib/unbound/root.hints
+    owner: unbound
+    group: unbound
+
+- name: Generate unbound config
+  template:
+    src: "templates/unbound.conf"
+    dest: "/etc/unbound/unbound.conf"
+  notify: "reboot the server"
+
+- name: Enable and start unbound service
+  systemd:
+    name: unbound
+    enabled: yes
+    state: started
+  notify: "reboot the server"
+
+- name: Set var/lib/unbound ownership
+  file:
+    path: /var/lib/unbound
+    owner: unbound
+    group: unbound
+    recurse: yes 
+
+- name: Turn off resolved (in Ubuntu 18.04)
+  lineinfile:
+    path: /etc/systemd/resolved.conf
+    regexp: '^DNSStubListener='
+    line: 'DNSStubListener=no'
+    create: no
+  notify: "reboot the server"
+  register: remove_resolved
+
+- name: Disable the resolved service (in Ubuntu 18.04)  # https://askubuntu.com/a/907249
+  systemd:
+    name: systemd-resolved.service
+    enabled: no
+    state: stopped
+  notify: "reboot the server"
+  when: remove_resolved.changed  # Lest we make errors for those without resolved
+  
+- name: Delete the resolved-symlinked resolv.conf (in Ubuntu 18.04)  # https://askubuntu.com/a/907249
+  file:
+    path: "/etc/resolv.conf"
+    state: absent
+  notify: "reboot the server"
+  when: remove_resolved.changed
+
+# TODO: This needs further testing (run the whole playbook against a freshly
+# re-imaged server)
+#
+# https://www.pcextreme.nl/community/d/94-unbound-local-dns-cache-on-ubuntu-and-centos
+- name: Configure the system to use the local unbound DNS (in Ubuntu 18.04)
+  lineinfile:
+    path: /etc/resolv.conf
+    regexp: '^nameserver'
+    line: 'nameserver 127.0.0.1'
+    create: yes
+  when: remove_resolved.changed

--- a/roles/wireguard/tasks/generate_keys.yml
+++ b/roles/wireguard/tasks/generate_keys.yml
@@ -1,0 +1,106 @@
+#The server keys will be 0.private and 0.public. The client keys will start from 1 onwards.
+#Note the number of clients is declared in "defaults/main.yml".
+
+# This is how we avoid generating new keys every time this is run.
+# To force re-generating everything, before running the
+# playbook go on the server and do
+#     wg-quick down wg0 && rm /etc/wireguard/wg0.conf 
+# (simply removing wg0.conf without previously shutting down the service
+# will make it impossible to shut down the service in an orderly fashion!
+# You will have to manually re-create a wg0.conf file before it will exit.)
+- name: Check if wg0-server.conf already exists
+  stat:
+    path: /etc/wireguard/wg0.conf
+  register: wg0_conf
+
+- name: Generate private and public keys for the client and server
+  shell: umask 077; wg genkey | tee {{ item }}.private | wg pubkey > {{ item }}.public
+  register: key_files
+  with_sequence: start=0 end={{ clients }}
+  when: wg0_conf is not defined or wg0_conf.stat.exists == false
+
+- name: Register private key file contents
+  shell: cat {{ item }}.private
+  register: private_key_files
+  with_sequence: start=0 end={{ clients }}
+  when: wg0_conf is not defined or wg0_conf.stat.exists == false
+
+- name: Register public key file contents
+  shell: cat {{ item }}.public
+  register: public_key_files
+  with_sequence: start=0 end={{ clients }}
+  when: wg0_conf is not defined or wg0_conf.stat.exists == false
+
+# Client configs are traditionally named wg0-client.conf, this lets
+# us keep that scheme.
+- name: Generate directories for client configs
+  file:
+    path: "~/wg_clients/client_{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0600
+  with_sequence: start=1 end={{ clients }}
+  when: wg0_conf is not defined or wg0_conf.stat.exists == false
+      
+- name: Generate client configs
+  template:
+    src: "templates/client.conf"
+    dest: "~/wg_clients/client_{{ item }}/wg0-client.conf"
+    owner: root
+    group: root
+    mode: 0600
+  with_sequence: start=1 end={{ clients }}
+  when: wg0_conf is not defined or wg0_conf.stat.exists == false
+  
+  
+# Else an already-running service will overwrite the local
+# config we are about to create when it quits
+- name: Stop any running Wireguard service
+  systemd:
+    name: wg-quick@wg0.service
+    state: stopped
+  when: wg0_conf is not defined or wg0_conf.stat.exists == false
+
+
+# Sometimes systemd doesn't do the job
+- name: Stop any running Wireguard service directly
+  shell: "wg-quick down wg0 || true"  # ignore failures
+  register: wg_quick_down_out  # For debugging
+  when: wg0_conf is not defined or wg0_conf.stat.exists == false
+
+# Should happen last among the config file creations, so if the process 
+# is interrupted we will re-generate everything (the existence of the 
+# server config is used to determine whether to generate the server and 
+# client config files)
+- name: Generate server config
+  template:
+    src: "templates/server.conf"
+    dest: "/etc/wireguard/wg0.conf"
+    owner: root
+    group: root
+    mode: 0600
+  when: wg0_conf.stat is not defined or wg0_conf.stat.exists == false
+
+- name: Print server public key
+  debug:
+    var: public_key_files.results[0].stdout
+  when: wg0_conf.stat is not defined or wg0_conf.stat.exists == false
+
+- name: Enable wireguard interface
+  systemd:
+    name: wg-quick@wg0
+    enabled: yes
+    state: started
+  # when is omitted since state should be `started` regardless
+
+- name: Register the clients on the vpn server
+  shell: wg set wg0 peer {{ public_key_files.results[item|int].stdout }} allowed-ips {{ vpn_network }}.{{item|int + 1}}/32
+  with_sequence: start=1 end={{ clients }}
+  when: wg0_conf is not defined or wg0_conf.stat.exists == false
+
+- name: Restart the VPN service to save changes
+  systemd:
+    name: wg-quick@wg0.service
+    state: restarted
+  when: wg0_conf is not defined or wg0_conf.stat.exists == false

--- a/roles/wireguard/tasks/install_wireguard.yml
+++ b/roles/wireguard/tasks/install_wireguard.yml
@@ -1,0 +1,19 @@
+- name: Determine the running kernel release
+  command: uname -r
+  register: kernel_release
+
+- name: Add the WireGuard PPA
+  apt_repository:
+    repo: 'ppa:wireguard/wireguard'
+
+# Using with_items loop for apt module is deprecated
+- name: Install WireGuard and other requirements 
+  apt:
+    name:
+      - linux-headers-{{ kernel_release.stdout }}
+      - linux-headers-generic
+      - wireguard-dkms
+      - wireguard-tools
+      - python2.7        
+    state: present
+    update_cache: true

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+# tasks file for wireguard_role
+
+- name: Install wireguard and other prequisites on the server
+  include: 'install_wireguard.yml'
+  tags: install_wireguard
+
+- name: Generate client keys and enable wireguard interface
+  include: 'generate_keys.yml'
+  tags: generate_keys
+
+- name: Set up nat and firewall rules
+  include: 'nat_and_firewall.yml'
+  tags: nat_and_firewall
+
+- name: Set up unbound for DNS operations
+  include: 'dns.yml'
+  tags: dns

--- a/roles/wireguard/tasks/nat_and_firewall.yml
+++ b/roles/wireguard/tasks/nat_and_firewall.yml
@@ -1,0 +1,79 @@
+- name: Enable IPv4 traffic forwarding
+  sysctl:
+    name: net.ipv4.ip_forward
+    value: 1
+    sysctl_set: yes
+    state: present
+    reload: yes
+
+- name: Enable IPv4 forwarding continued
+  command: echo 1 > /proc/sys/net/ipv4/ip_forward
+
+#Set up firewall rules
+- name: Track input chain
+  iptables:
+    chain: INPUT
+    match: conntrack
+    ctstate: ESTABLISHED,RELATED
+    jump: ACCEPT
+
+- name: Track forward chain  
+  iptables:
+    chain: FORWARD
+    match: conntrack
+    ctstate: ESTABLISHED,RELATED
+    jump: ACCEPT
+
+- name: Allow incoming wireguard connections    
+  iptables:
+    chain: INPUT
+    protocol: udp
+    match: udp
+    destination_port: "{{ vpn_port }}"
+    ctstate: NEW
+    jump: ACCEPT
+   
+- name: Allow recursive DNS tcp    
+  iptables:
+    chain: INPUT
+    source: "{{ vpn_network }}.0/24"
+    protocol: tcp
+    match: tcp
+    destination_port: 53
+    ctstate: NEW
+    jump: ACCEPT
+  
+- name: Allow recursive DNS udp  
+  iptables:
+    chain: INPUT
+    source: "{{ vpn_network }}.0/24"
+    protocol: udp
+    match: udp
+    destination_port: 53
+    ctstate: NEW
+    jump: ACCEPT
+    
+- name: Allow forwarding of packets that stay in the tunnel 
+  iptables:
+    chain: FORWARD
+    in_interface: wg0
+    match: conntrack
+    out_interface: wg0
+    ctstate: NEW
+    jump: ACCEPT
+
+- name: Set up NAT
+  iptables:
+    table: nat
+    chain: POSTROUTING
+    source: "{{ vpn_network }}.0/24"
+    out_interface: "{{ ansible_default_ipv4.interface }}"
+    jump: MASQUERADE  
+
+- name: Install iptables-persistent
+  apt: pkg=iptables-persistent state=present update_cache=true
+
+- name: Set up iptables persistence
+  command: netfilter-persistent save
+
+

--- a/roles/wireguard/templates/client.conf
+++ b/roles/wireguard/templates/client.conf
@@ -1,0 +1,10 @@
+[Interface]
+Address = {{ vpn_network }}.{{item|int + 1}}/32
+DNS = {{ vpn_network }}.1
+PrivateKey = {{ private_key_files.results[item|int].stdout }}
+
+[Peer]
+PublicKey = {{ public_key_files.results[0].stdout }}
+AllowedIPs = 0.0.0.0/0
+Endpoint = {{ ansible_default_ipv4.address }}:{{ vpn_port }}
+PersistentKeepalive = 21

--- a/roles/wireguard/templates/server.conf
+++ b/roles/wireguard/templates/server.conf
@@ -1,0 +1,5 @@
+[Interface]
+Address = {{ vpn_network }}.1/24
+SaveConfig = true
+ListenPort = {{ vpn_port }}
+PrivateKey = {{ private_key_files.results[0].stdout }}

--- a/roles/wireguard/templates/unbound.conf
+++ b/roles/wireguard/templates/unbound.conf
@@ -1,0 +1,47 @@
+server:
+
+  num-threads: 4
+
+  #Enable logs
+  verbosity: 1
+
+  #list of Root DNS Server
+  root-hints: "/var/lib/unbound/root.hints"
+
+  #Use the root servers key for DNSSEC
+  auto-trust-anchor-file: "/var/lib/unbound/root.key"
+
+  #Respond to DNS requests on all interfaces
+  interface: 0.0.0.0
+  max-udp-size: 3072
+
+  #Authorized IPs to access the DNS Server
+  access-control: 0.0.0.0/0                 refuse
+  access-control: 127.0.0.1                 allow
+  access-control: {{ vpn_network }}.0/24	   		allow
+
+  #not allowed to be returned for public internet  names
+  private-address: {{ vpn_network }}.0/24
+
+  # Hide DNS Server info
+  hide-identity: yes
+  hide-version: yes
+     
+  #Limit DNS Fraud and use DNSSEC
+  harden-glue: yes
+  harden-dnssec-stripped: yes
+  harden-referral-path: yes
+
+  #Add an unwanted reply threshold to clean the cache and avoid when possible a DNS Poisoning
+  unwanted-reply-threshold: 10000000
+
+  #Have the validator print validation failures to the log.
+  val-log-level: 1
+
+  #Minimum lifetime of cache entries in seconds
+  cache-min-ttl: 1800	
+
+  #Maximum lifetime of cached entries
+  cache-max-ttl: 14400
+  prefetch: yes
+  prefetch-key: yes

--- a/roles/wireguard/tests/inventory
+++ b/roles/wireguard/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/wireguard/tests/test.yml
+++ b/roles/wireguard/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: {{ user.name }}
+  roles:
+    - wireguard

--- a/roles/wireguard/vars/main.yml
+++ b/roles/wireguard/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for wireguard_role


### PR DESCRIPTION
all ansible scripts taken from iamckn/wireguard_ansible
adjusted for use in Cloudbox Community

Role installs wireguard and generates ten client profiles, essentially turning your cloudbox server into a 10-client wireguard VPN server. Installs unbound for local dns resolving, configures that and iptables to make sure everything works out.

Could you please quickly check if everything is alright? Its working on my end but one never knows.
When its merged I will write a little wiki article for where to find the profiles and recommend to reboot after installing this.