### PR TITLE
add override setting for unifi inform port 

### DIFF
--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -38,3 +38,5 @@ transmissionvpn:
   vpn_pass: your_vpn_password
   vpn_prov: NORDVPN
   vpn_endpoint: Netherlands.ovpn
+unifi:
+  inform_port: 8080

--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -39,4 +39,4 @@ transmissionvpn:
   vpn_prov: NORDVPN
   vpn_endpoint: Netherlands.ovpn
 unifi:
-  inform_port: 8080
+  port: 8080

--- a/roles/settings/tasks/main.yml
+++ b/roles/settings/tasks/main.yml
@@ -11,7 +11,6 @@
 - name: "Install ruamel.yaml"
   pip:
     name: ruamel.yaml
-    version: 0.15.35
     executable: pip3
 
 - name: "Get 'community.yml' info."

--- a/roles/unifi/tasks/main.yml
+++ b/roles/unifi/tasks/main.yml
@@ -36,7 +36,7 @@
     image: "linuxserver/unifi-controller:latest"
     published_ports:
       - 3478:3478/udp
-      - "{{ unifi.inform_port|default('8089',true) }}:8080"
+      - "{{ unifi.port|default('8089',true) }}:8080"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"

--- a/roles/unifi/tasks/main.yml
+++ b/roles/unifi/tasks/main.yml
@@ -36,7 +36,7 @@
     image: "linuxserver/unifi-controller:latest"
     published_ports:
       - 3478:3478/udp
-      - 8089:8080
+      - "{{ unifi.inform_port|default('8089',true) }}:8080"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"


### PR DESCRIPTION
add override setting for unifi inform port to allow default 8080 to be used

unifi devices expect the inform port to be 8080 so this is easier to deploy, but still allows overriding if necessary.

I've left the 8089 as the in-file default as per the existing, but set the settings.yml.default to have 8080 as a default.

I've tested with a `sudo ansible-playbook community.yml --tags unifi` and the container was successfully started with 8080:8080 mapped.