### PR TITLE
TransmissionVPN: Slight changes to default_volumes

### DIFF
--- a/roles/transmissionvpn/tasks/main.yml
+++ b/roles/transmissionvpn/tasks/main.yml
@@ -44,6 +44,8 @@
       - "/opt/transmissionvpn/vpn:/etc/openvpn/custom"
       - "/mnt:/mnt"
       - "/opt/transmissionvpn:/opt/transmissionvpn"
+      - "/mnt/local/downloads/torrents/TransmissionVPN:/data"
+      - "/opt/transmissionvpn:/config"
 
 - name: Create and start container
   docker_container:


### PR DESCRIPTION
Added mounts for container's /data and /config so Docker does not automatically create Docker volumes on the main storage to host these