### PR TITLE
Added -P flag to kitana role

### DIFF
--- a/roles/kitana/tasks/main.yml
+++ b/roles/kitana/tasks/main.yml
@@ -39,6 +39,7 @@
       VIRTUAL_PORT: "31337"
       LETSENCRYPT_HOST: "kitana.{{ user.domain }}"
       LETSENCRYPT_EMAIL: "{{ user.email }}"
+    command: -P
     volumes:
       - "/opt/kitana:/data"
     labels:


### PR DESCRIPTION
Kitana doesn't realize its being run behind a reverse proxy so its
trying to request resources from non secure url's. This flag corrects
that behavior.