### PR TITLE
Ouroboros: Change to env file configuration

### DIFF
--- a/roles/ouroboros/tasks/main.yml
+++ b/roles/ouroboros/tasks/main.yml
@@ -14,12 +14,32 @@
     name: ouroboros
     state: absent
 
+- name: Create ouroboros directories
+  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }} recurse=yes"
+  with_items:
+    - /opt/ouroboros
+
+- name: "Check if ouroboros.env file exists"
+  stat:
+    path: "/opt/ouroboros/ouroboros.env"
+  register: ouroboros_env
+
+- name: "Import ouroboros.env if it doesnt exist"
+  template:
+    src: ouroboros.env.j2
+    dest: /opt/ouroboros/ouroboros.env
+    force: yes
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0775
+  when: not ouroboros_env.stat.exists
+
 - name: Create container
   docker_container:
     name: ouroboros
     image: "pyouroboros/ouroboros"
     pull: yes
-    command: "--cleanup"
+    env_file: /opt/ouroboros/ouroboros.env
     env:
       TZ: "{{ tz }}"
     volumes:

--- a/roles/ouroboros/templates/ouroboros.env.j2
+++ b/roles/ouroboros/templates/ouroboros.env.j2
@@ -1,0 +1,2 @@
+SELF_UPDATE=true
+CLEANUP=true


### PR DESCRIPTION
To allow for additional user configuration which remains persistent, the role will now import ouroboros.env into /opt/ouroboros/ouroboros.env and load that as an ENV file for the Docker container.