### PR TITLE
Wordpress: Update Image

### DIFF
--- a/roles/wordpress/tasks/main.yml
+++ b/roles/wordpress/tasks/main.yml
@@ -36,7 +36,7 @@
 - name: Create and start wordpress container
   docker_container:
     name: wordpress
-    image: "wordpress"
+    image: "wordpress:5.3.2-php7.2-apache"
     pull: yes
     user: "{{ uid }}:{{ gid }}"
     env:

--- a/roles/wordpress/tasks/main.yml
+++ b/roles/wordpress/tasks/main.yml
@@ -36,9 +36,8 @@
 - name: Create and start wordpress container
   docker_container:
     name: wordpress
-    image: "wordpress:5.3.2-php7.2-apache"
+    image: "wordpress:latest"
     pull: yes
-    user: "{{ uid }}:{{ gid }}"
     env:
       TZ: "{{ tz }}"
       WORDPRESS_DB_HOST: "mariadb:3306"


### PR DESCRIPTION
The "latest" tag for wordpress is no longer based on alpine, passing through the UID and GID of the user only works with alpine. This was causing wordpress to fail to start, updated image to this alpine specific version, unfortunately unable to find a way to use "latest" but continue specifying which user to run as.