### PR TITLE
Tdarr: add environment variable to enable nvidia gpu transcoding

### DIFF
--- a/roles/tdarr/tasks/main.yml
+++ b/roles/tdarr/tasks/main.yml
@@ -54,6 +54,9 @@
       VIRTUAL_PORT: "8265"
       LETSENCRYPT_HOST: "tdarr.{{ user.domain }}"
       LETSENCRYPT_EMAIL: "{{ user.email }}"
+      NVIDIA_DRIVER_CAPABILITIES: "{{ 'compute,video,utility' if gpu.nvidia | default(false) else omit }}"
+      NVIDIA_VISIBLE_DEVICES: "{{ 'all' if gpu.nvidia | default(false) else omit }}"
+
     volumes:
       - "/mnt/unionfs/Media:/home/Tdarr/media"
       - "/opt/tdarr/config:/home/Tdarr/Documents/Tdarr"

--- a/roles/tdarr/tasks/main.yml
+++ b/roles/tdarr/tasks/main.yml
@@ -54,7 +54,7 @@
       VIRTUAL_PORT: "8265"
       LETSENCRYPT_HOST: "tdarr.{{ user.domain }}"
       LETSENCRYPT_EMAIL: "{{ user.email }}"
-      NVIDIA_DRIVER_CAPABILITIES: "{{ 'compute,video,utility' if gpu.nvidia | default(false) else omit }}"
+      NVIDIA_DRIVER_CAPABILITIES: "{{ 'all' if gpu.nvidia | default(false) else omit }}"
       NVIDIA_VISIBLE_DEVICES: "{{ 'all' if gpu.nvidia | default(false) else omit }}"
 
     volumes:


### PR DESCRIPTION
Tdarr: add environment variable to enable nvidia gpu transcoding when the appropriate hardware is available. Code borrowed from the Jellyfin role