### PR TITLE
[deezloader-remix] Add /mnt to deezer image

### DIFF
--- a/roles/deezloader-remix/tasks/main.yml
+++ b/roles/deezloader-remix/tasks/main.yml
@@ -55,6 +55,7 @@
     volumes:
       - "/mnt/unionfs/Media/deezer:/downloads:rw"
       - "/opt/deezloader/config:/config:rw"
+      - "/mnt:/mnt:rw"
     labels:
       "com.github.cloudbox.cloudbox_managed": "true"
     networks:


### PR DESCRIPTION
Add /mnt so different file structures can be used if necessary.