### PR TITLE
EmbyStat: use beta tag

### DIFF
--- a/roles/embystat/tasks/main.yml
+++ b/roles/embystat/tasks/main.yml
@@ -38,7 +38,7 @@
 - name: Create and start container
   docker_container:
     name: embystat
-    image: "uping/embystat:nightly-ubuntu-x64"
+    image: "uping/embystat:beta"
     pull: yes
     volumes:
       - "/opt/embystat/config:/app/config:rw"


### PR DESCRIPTION
EmbyStat is really unstable with the nightly builds had an error with it such as 

``` 
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at EmbyStat.Web.Program.Main(String[] args) in d:\a\1\s\EmbyStat.Web\Program.cs:line 49
```

couldn't connect to the server pretty much just giving 

`502 Bad Gateway nginx/1.17.6 `

changing the tag to beta seem fixed the issue and it's more stable. 