### PR TITLE
Synclounge: Disabled HTTPS redirect

### DIFF
--- a/roles/synclounge/tasks/main.yml
+++ b/roles/synclounge/tasks/main.yml
@@ -41,6 +41,7 @@
       VIRTUAL_PORT: "80"
       LETSENCRYPT_HOST: "{{ synclounge.subdomain|default('synclounge',true) }}.{{ synclounge.domain | default(user.domain,true) }}"
       LETSENCRYPT_EMAIL: "{{user.email}}"
+      HTTPS_METHOD: noredirect
     labels:
       "com.github.cloudbox.cloudbox_managed": "true"
     networks:


### PR DESCRIPTION
Synclounge cannot use HTTPS to connect to external Plex Clients while loading the page via HTTPS.
Issue detailed here: https://github.com/samcm/synclounge/issues/52

Therefore, the only way to let it **use external Plex clients** (i.e. PMP) and not only Synclounge Player (browser based) is to enable HTTP access. This is done through nginx-proxy via the env variable HTTPS_METHOD, detailed here: https://hub.docker.com/r/jwilder/nginx-proxy