### PR TITLE
Remove -it flags from cron job

### DIFF
--- a/roles/beets/tasks/main.yml
+++ b/roles/beets/tasks/main.yml
@@ -73,7 +73,7 @@
     name: "Beets Import"
     user: "{{ user.name }}"
     special_time: hourly
-    job: "docker exec -u abc -it beets /bin/bash -c 'beet import -q /downloads'"
+    job: "docker exec -u abc beets /bin/bash -c 'beet import -q /downloads'"
     state: present
 
 - name: Wait for config.yaml to be created

--- a/roles/plex2/defaults/main.yml
+++ b/roles/plex2/defaults/main.yml
@@ -54,7 +54,7 @@ plex2_docker_volumes:
 
 localhost_ip: "127.0.0.1"
 
-lazyman_ip: "{{ ( lookup('dig', 'powersports.ml', '@8.8.8.8', 'qtype=A') | ipv4 ) | default(false,true) }}"
+lazyman_ip: "{{ ( lookup('dig', 'nhl.freegamez.ga', '@8.8.8.8', 'qtype=A') | ipv4 ) | default(false,true) }}"
 
 plex_default_hosts:
   "metric.plex.tv": "{{ localhost_ip }}"


### PR DESCRIPTION
The flags -it for a docker exec command running via cron aren't needed and in fact error out with "The input device is not a TTY".