### PR TITLE
Add DNS Server to Transmission VPN Docker

### DIFF
--- a/roles/plex2/defaults/main.yml
+++ b/roles/plex2/defaults/main.yml
@@ -54,7 +54,7 @@ plex2_docker_volumes:
 
 localhost_ip: "127.0.0.1"
 
-lazyman_ip: "{{ ( lookup('dig', 'powersports.ml', '@8.8.8.8', 'qtype=A') | ipv4 ) | default(false,true) }}"
+lazyman_ip: "{{ ( lookup('dig', 'nhl.freegamez.ga', '@8.8.8.8', 'qtype=A') | ipv4 ) | default(false,true) }}"
 
 plex_default_hosts:
   "metric.plex.tv": "{{ localhost_ip }}"

--- a/roles/transmissionvpn/tasks/main.yml
+++ b/roles/transmissionvpn/tasks/main.yml
@@ -71,6 +71,7 @@
       TRANSMISSION_HOME: "/opt/transmissionvpn"
       TZ: "{{ tz }}"
     volumes: "{{ default_volumes + torrents_downloads_path|default([]) }}"
+    dns_servers: 8.8.8.8
     labels:
       "com.github.cloudbox.cloudbox_managed": "true"
     capabilities:


### PR DESCRIPTION
Necessary for Transmission to open port on load.