### PR TITLE
Tdarr: changed container from tdarr_aio to tdarr

### DIFF
--- a/roles/tdarr/tasks/main.yml
+++ b/roles/tdarr/tasks/main.yml
@@ -2,7 +2,7 @@
 # Title:            Community: Tdarr                                    #
 # Author(s):        Visorak, Migz                                       #
 # URL:              https://github.com/Cloudbox/Community               #
-# Docker Image(s):  haveagitgat/tdarr_aio                               #
+# Docker Image(s):  haveagitgat/tdarr                                   #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################

--- a/roles/tdarr/tasks/main.yml
+++ b/roles/tdarr/tasks/main.yml
@@ -42,7 +42,7 @@
 - name: Create and start container
   docker_container:
     name: tdarr
-    image: haveagitgat/tdarr_aio
+    image: haveagitgat/tdarr
     pull: yes
     published_ports:
       - "127.0.0.1:8265:8265"


### PR DESCRIPTION
As per changes to the source container:
Change log

Beta v1.1091 release [24th May 2020]:

All containers are now the same (tdarr, tdarr_aio, tdarr_aio:qsv) and are based on the tdarr_aio:qsv container which supports NVENC and QSV hardware transcoding.

tdarr_aio and tdarr_aio:qsv users, you can continue using those containers as normal and will receive updates. You don't need to do anything.

Users who were previously using the tdarr container will need to set up the container again and restore from a backup. There is now no need for a separate MongoDB container. Please see the following for help:
http://tdarr.io/tools
https://github.com/HaveAGitGat/Tdarr/wiki/2---Installation

