### PR TITLE
Jellyfin: Updated Role

### DIFF
--- a/roles/jellyfin/tasks/main.yml
+++ b/roles/jellyfin/tasks/main.yml
@@ -93,7 +93,6 @@
       - "/opt/jellyfin:/config:rw"
       - "/opt/scripts:/scripts"
       - "/mnt:/mnt:rw"
-      - "/mnt/strm:/strm:rw"
       - "/mnt/unionfs/Media:/media"
       - "/mnt/unionfs/Media:/data"
       - "{{ plex.transcodes }}/jellyfin:/transcode"


### PR DESCRIPTION
Updated role to remove /mnt/strm path being mapped. This can be accessed via the /mnt path that is already added.