### PR TITLE
Add role: mylar3 (v3 for mylar)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Community Repository for Unofficial Cloudbox Add-ons
 - **monitorr**
 - **[jdownloader2](../../wiki/JDownloader2)** - [JDownloader2](https://github.com/jlesage/docker-jdownloader-2) Self-hosted free, open-source download management tool with GUI website frontend.
 - **mylar** - automated comic book downloader
+- **mylar3** - newest version of the automated comic book downloader, migrated to python 3. Actively developed.
 - **[qBittorrent](../../wiki/qBittorrent)** - qBittorrent torrent client
 - **radarr1080** - Additional Radarr
 - **radarrX** - Similar to [sonarrX](../../wiki/SonarrX) but for radarr, to create multiple roles

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,6 +59,7 @@ environment:
     minecraft
     monitorr
     mylar
+    mylar3
     nextcloud
     nowshowing
     nzbhydra

--- a/community.yml
+++ b/community.yml
@@ -58,6 +58,7 @@
     - { role: minecraft, tags: ['minecraft'] }
     - { role: monitorr, tags: ['monitorr'] }
     - { role: mylar, tags: ['mylar'] }
+    - { role: mylar3, tags: ['mylar3'] }
     - { role: nextcloud, tags: ['nextcloud'] }
     - { role: nowshowing, tags: ['nowshowing'] }
     - { role: nzbhydra, tags: ['nzbhydra'] }

--- a/roles/mylar3/tasks/main.yml
+++ b/roles/mylar3/tasks/main.yml
@@ -1,0 +1,59 @@
+#########################################################################
+# Title:            Community: Mylar3                                   #
+# Author(s):        theotocopulitos                                     #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image(s):  ajslater/mylar3                                     #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: "Setting CloudFlare DNS Record"
+  include_role:
+    name: cloudflare-dns
+  vars:
+    record: mylar3
+  when: cloudflare_enabled
+
+- name: Stop and remove any existing container
+  docker_container:
+    name: mylar3
+    state: absent
+
+- name: Create mylar3 directories
+  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }}"
+  with_items:
+    - /opt/mylar3
+    - /mnt/local/Media/Comics
+
+- name: Create and start container
+  docker_container:
+    name: mylar3
+    image: ajslater/mylar3
+    pull: yes
+    published_ports:
+      - "127.0.0.1:8091:8090"
+    env:
+      PUID: "{{ uid }}"
+      PGID: "{{ gid }}"
+      VIRTUAL_HOST: "mylar3.{{ user.domain }}"
+      VIRTUAL_PORT: "8090"
+      LETSENCRYPT_HOST: "mylar3.{{ user.domain }}"
+      LETSENCRYPT_EMAIL: "{{ user.email }}"
+    volumes:
+      - "/opt/mylar3:/config"
+      - "/mnt/local/downloads:/downloads"
+      - "/mnt/unionfs/Media/Comics:/comics"
+      - "/mnt:/mnt"
+      - "/etc/timezone:/etc/timezone:ro"
+      - "/etc/localtime:/etc/localtime:ro"
+    labels:
+      "com.github.cloudbox.cloudbox_managed": "true"
+    networks:
+      - name: cloudbox
+        aliases:
+          - mylar3
+    purge_networks: yes
+    restart_policy: unless-stopped
+    state: started


### PR DESCRIPTION
Mylar3 is the port of mylar (comics downloader) to phyton 3. Developement has stopped on mylar and is now set on mylar3.

I changed the TZ from the original mylar main.yml mounting /etc/timezone as volume, since the original own in mylar was not working.