### PR TITLE
Fix port conflict (medusa and calibre-web)

### DIFF
--- a/roles/medusa/tasks/main.yml
+++ b/roles/medusa/tasks/main.yml
@@ -40,7 +40,7 @@
     image: linuxserver/medusa
     pull: yes
     published_ports:
-      - "127.0.0.1:8083:8081"
+      - "127.0.0.1:8084:8081"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"


### PR DESCRIPTION
Currently both medusa and calibre-web bind to 8083 on host by default. It would probably be preferable to have separate ports by  default.