### PR TITLE
Fix Emby2

### DIFF
--- a/roles/emby2/tasks/main.yml
+++ b/roles/emby2/tasks/main.yml
@@ -39,8 +39,6 @@
     name: emby2
     image: "emby/embyserver:{{ emby.version }}"
     pull: yes
-    published_ports:
-      - "127.0.0.1:8096:8096"
     env:
       UID: "{{ uid }}"
       GID: "{{ gid }}"


### PR DESCRIPTION
The published localhost port conflicts with the Emby role if installed on the same system. Removed it since it doesn't seem to be needed.