### PR TITLE
SonarrX: Update Docker image tag

### DIFF
--- a/roles/sonarrx/tasks/template.yml
+++ b/roles/sonarrx/tasks/template.yml
@@ -47,7 +47,7 @@
 - name: Create and start container
   docker_container:
     name: "sonarr{{ rolename }}"
-    image: "hotio/sonarr:phantom"
+    image: "hotio/sonarr:nightly"
     pull: yes
     published_ports:
       - "127.0.0.1:{{ roleport }}:8989"

--- a/roles/sonarrx/tasks/template.yml
+++ b/roles/sonarrx/tasks/template.yml
@@ -2,7 +2,7 @@
 # Title:            Community: SonarrX | Template                       #
 # Author(s):        Kalroth, Migz93                                     #
 # URL:              https://github.com/Cloudbox/Community               #
-# Docker Image(s):  hotio/sonarr, hotio/sonarr3                         #
+# Docker Image(s):  hotio/sonarr                                        #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################


### PR DESCRIPTION
`phantom` tag deprecated in favor of `nightly` tag