### PR TITLE
DelugeVPN: Update OpenVPN configuration to PIA NextGen

### DIFF
--- a/roles/delugevpn/tasks/main.yml
+++ b/roles/delugevpn/tasks/main.yml
@@ -30,7 +30,7 @@
 
 - name: Get the OpenVPN configuration files and certs
   unarchive:
-    src: https://www.privateinternetaccess.com/openvpn/openvpn.zip
+    src: https://www.privateinternetaccess.com/openvpn/openvpn-nextgen.zip
     dest: /opt/delugevpn/piaconfigs
     remote_src: yes
 


### PR DESCRIPTION
Docker image has now been updated to support PIA NextGen.
https://github.com/binhex/arch-delugevpn/issues/197#issuecomment-700652539

Updated the download link for OpenVPN configurations to the next gen link. ZIP structure is the same as before and in my environment this appears to work as a slot in replacement.

Theoretically the same applies to binhex's other VPN containers but I don't run any of the others, if people would like to test.