### PR TITLE
restricted komga ports to only accept requests from 127.0.01 (proxied)

### DIFF
--- a/roles/komga/tasks/main.yml
+++ b/roles/komga/tasks/main.yml
@@ -33,7 +33,7 @@
     image: gotson/komga
     pull: yes
     published_ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"


### PR DESCRIPTION
noticed that with the current setup, komga accepts requests from my.cloudbox.host:8080.

changed ports setup to only allow nginx proxied requests