### PR TITLE
Add role for HomeAssistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Community Repository for Unofficial Cloudbox Add-ons
 - **[glances](http://nicolargo.github.io/glances/)** - Please have a look at the [official documentation](https://glances.readthedocs.io/en/latest/).
 - **[goplaxt](../../wiki/Goplaxt)** - [goplaxt](https://github.com/XanderStrike/goplaxt) Plex/Trakt Scrobbler
 - **Handbrake** - GUI application (no installation or configuration needed on client-side)
+- **homeassistant** - [Home Assistant](https://www.home-assistant.io) - Open source home automation that puts local control and privacy first.
 - **invoiceninja**
 - **jellyfin** - [jellyfin](https://github.com/jellyfin/jellyfin) emby fork
 - **kitana** - A responsive Plex plugin web frontend

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,7 @@ environment:
     handbrake
     healthchecks
     heimdall
+    homeassistant
     invoiceninja
     jdownloader2
     jellyfin

--- a/community.yml
+++ b/community.yml
@@ -49,6 +49,7 @@
     - { role: healthchecks, tags: ['healthchecks'] }
     - { role: heimdall, tags: ['heimdall'] }
     - { role: hetzner_nfs, tags: ['hetzner_nfs_server', 'hetzner_nfs_server_uninstall', 'hetzner_nfs_client_mount', 'hetzner_nfs_client_unmount'] }
+    - { role: homeassistant, tags: ['homeassistant'] }
     - { role: invoiceninja, tags: ['invoiceninja'] }
     - { role: jellyfin, tags: ['jellyfin'] }
     - { role: jirafeau, tags: ['jirafeau'] }

--- a/roles/homeassistant/tasks/main.yml
+++ b/roles/homeassistant/tasks/main.yml
@@ -52,6 +52,7 @@
     devices: "{{ '/dev/dri:/dev/dri' if (gpu.intel and dev_dri.stat.exists) | default(false) else omit }}"
     labels:
       "com.github.cloudbox.cloudbox_managed": "true"
+    network_mode: host
     networks:
       - name: cloudbox
         aliases:

--- a/roles/homeassistant/tasks/main.yml
+++ b/roles/homeassistant/tasks/main.yml
@@ -53,10 +53,6 @@
     labels:
       "com.github.cloudbox.cloudbox_managed": "true"
     network_mode: host
-    networks:
-      - name: cloudbox
-        aliases:
-          - homeassistant
     purge_networks: yes
     restart_policy: unless-stopped
     state: started

--- a/roles/homeassistant/tasks/main.yml
+++ b/roles/homeassistant/tasks/main.yml
@@ -1,0 +1,63 @@
+#########################################################################
+# Title:            Community: HomeAssistant                            #
+# Author(s):        kenyonj                                             #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image(s):  homeassistant/home-assistant                        #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: "Setting CloudFlare DNS Record"
+  include_role:
+    name: cloudflare-dns
+  vars:
+    record: homeassistant
+  when: cloudflare_enabled
+
+- name: Stop and remove any existing container
+  docker_container:
+    name: homeassistant
+    state: absent
+
+- name: Create homeassistant directories
+  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }}"
+  with_items:
+    - /opt/homeassistant
+
+- name: "Check if '/dev/dri' exists"
+  stat:
+    path: "/dev/dri"
+  register: dev_dri
+
+- name: Create and start container
+  docker_container:
+    name: homeassistant
+    image: homeassistant/home-assistant:stable
+    pull: yes
+    published_ports:
+      - "127.0.0.1:8123:8123"
+    env:
+      TZ: "{{ tz }}"
+      PUID: "{{ uid }}"
+      PGID: "{{ gid }}"
+      VIRTUAL_HOST: "homeassistant.{{ user.domain }}"
+      VIRTUAL_PORT: "8123"
+      LETSENCRYPT_HOST: "homeassistant.{{ user.domain }}"
+      LETSENCRYPT_EMAIL: "{{ user.email }}"
+      CLEAN_TMP_DIR: "1"
+      ENABLE_CJK_FONT: "1"
+    volumes:
+      - "/etc/localtime:/etc/localtime:ro"
+      - "/opt/homeassistant:/config:rw"
+    devices: "{{ '/dev/dri:/dev/dri' if (gpu.intel and dev_dri.stat.exists) | default(false) else omit }}"
+    labels:
+      "com.github.cloudbox.cloudbox_managed": "true"
+    networks:
+      - name: cloudbox
+        aliases:
+          - homeassistant
+    purge_networks: yes
+    restart_policy: unless-stopped
+    state: started

--- a/roles/homeassistant/tasks/main.yml
+++ b/roles/homeassistant/tasks/main.yml
@@ -36,8 +36,6 @@
     name: homeassistant
     image: homeassistant/home-assistant:stable
     pull: yes
-    published_ports:
-      - "127.0.0.1:8123:8123"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"


### PR DESCRIPTION
This PR:
  - Adds the proper community.yml entry
  - Adds the role tasks for installing homeassistant
  - Adds an entry to the README
  - Adds appveyor entry

Why?
  - This is useful for allowing HomeAssistant to be installed with the
community scripts