### PR TITLE
Watchtower: Add ENV file configuration

### DIFF
--- a/roles/watchtower/tasks/main.yml
+++ b/roles/watchtower/tasks/main.yml
@@ -2,7 +2,7 @@
 # Title:         Community: Watchower Role                              #
 # Author(s):     l3uddz                                                 #
 # URL:           https://github.com/Cloudbox/Community                  #
-# Docker Image:  v2tec/watchtower                                       #
+# Docker Image:  containrrr/watchtower                                  #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################
@@ -14,12 +14,32 @@
     name: watchtower
     state: absent
 
+- name: Create watchtower directories
+  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }} recurse=yes"
+  with_items:
+    - /opt/watchtower
+
+- name: "Check if watchtower.env file exists"
+  stat:
+    path: "/opt/watchtower/watchtower.env"
+  register: watchtower_env
+
+- name: "Import watchtower.env if it doesnt exist"
+  template:
+    src: watchtower.env.j2
+    dest: /opt/watchtower/watchtower.env
+    force: yes
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0775
+  when: not watchtower_env.stat.exists
+
 - name: Create container
   docker_container:
     name: watchtower
     image: "containrrr/watchtower"
     pull: yes
-    command: "--cleanup"
+    env_file: /opt/watchtower/watchtower.env
     env:
       TZ: "{{ tz }}"
     volumes:
@@ -31,4 +51,5 @@
         aliases:
           - watchtower
     purge_networks: yes
-    state: stopped
+    state: started
+    restart: unless-stopped

--- a/roles/watchtower/tasks/main.yml
+++ b/roles/watchtower/tasks/main.yml
@@ -52,4 +52,4 @@
           - watchtower
     purge_networks: yes
     state: started
-    restart: unless-stopped
+    restart_policy: unless-stopped

--- a/roles/watchtower/templates/watchtower.env.j2
+++ b/roles/watchtower/templates/watchtower.env.j2
@@ -1,0 +1,2 @@
+TZ={{ tz }}
+WATCHTOWER_CLEANUP=true


### PR DESCRIPTION
Use pre-populated ENV file for configuration. Allows for user edits in the env file and re-running the role to re-deploy with persistent configuration.

This should be replaced with the variable-based approach when implemented on Community.