### PR TITLE
Update template.yml - Add published ports

### DIFF
--- a/roles/radarrx/tasks/template.yml
+++ b/roles/radarrx/tasks/template.yml
@@ -49,6 +49,8 @@
     name: "radarr{{ rolename }}"
     image: "hotio/radarr:nightly"
     pull: yes
+    published_ports:
+      - "127.0.0.1:{{ roleport }}:7878"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"


### PR DESCRIPTION
Add back published ports. Looks like they were removed when it was pushed to v3. 

Recreation of container removes published ports in docker which results in denied connections for services - mainly traktarr.


