### PR TITLE
Update main.yml

### DIFF
--- a/roles/guacamole/tasks/main.yml
+++ b/roles/guacamole/tasks/main.yml
@@ -1,6 +1,6 @@
 #########################################################################
 # Title:            Community: Guacamole                                #
-# Author(s):        RXWatcher                                           #
+# Author(s):        RXWatcher, willjgit                                 #
 # URL:              https://github.com/Cloudbox/Community               #
 # Docker Image(s):  jasonbean/guacamole                                 #
 # --                                                                    #
@@ -30,7 +30,7 @@
 - name: Create and start container
   docker_container:
     name: guacamole
-    image: jasonbean/guacamole:latest
+    image: oznu/guacamole:latest
     pull: yes
     env:
       TZ: "{{ tz }}"

--- a/roles/guacamole/tasks/main.yml
+++ b/roles/guacamole/tasks/main.yml
@@ -2,7 +2,7 @@
 # Title:            Community: Guacamole                                #
 # Author(s):        RXWatcher, willjgit                                 #
 # URL:              https://github.com/Cloudbox/Community               #
-# Docker Image(s):  jasonbean/guacamole                                 #
+# Docker Image(s):  oznu/guacamole                                      #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################
@@ -22,7 +22,7 @@
     state: absent
 
 - name: Create guacamole directories
-  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }} recurse=yes"
+  file: "path={{ item }} state=directory mode=0777 owner={{ user.name }} group={{ user.name }} recurse=yes"
   with_items:
     - /opt/guacamole
     - /opt/guacamole/config
@@ -55,6 +55,6 @@
     timeout: 30
 
 - name: Reset guacamole directories
-  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }} recurse=yes"
+  file: "path={{ item }} state=directory mode=0777 owner={{ user.name }} group={{ user.name }} recurse=yes"
   with_items:
     - /opt/guacamole


### PR DESCRIPTION
Updated the guacamole image to oznu's version using the postgres database. the jason-bean docker image has various instability errors with mariadb if you try to restart the container. Recommend that we switch the role to use the oznu docker image of Guacamole.

Tested image on my VPS -- works fine, and docker container works fine on reboot of container and server unlike the jason bean version.



- [ x] I have reviewed the [Contribute page in the wiki](https://github.com/Cloudbox/Community/wiki/Contribute)
- [x ] I have updated the header in any files I may have used as templates with my own information
- [N/A] I have added my new role to `appveyor.yml`
- [N/A ] I have added my new role to `community.yml`
- [x ] I have verified that any Docker images used are current and supported.
- [x ] I have made corresponding changes to the documentation
