### PR TITLE
TransmissionVPN: Fix Docker tag

### DIFF
--- a/roles/transmissionvpn/tasks/main.yml
+++ b/roles/transmissionvpn/tasks/main.yml
@@ -50,7 +50,7 @@
 - name: Create and start container
   docker_container:
     name: transmissionvpn
-    image: haugene/transmission-openvpn:latest-alpine
+    image: haugene/transmission-openvpn:latest
     pull: yes
     env:
       PUID: "{{ uid }}"


### PR DESCRIPTION
`:latest-alpine` deprecated, `:latest` now based on Alpine per dev.