### PR TITLE
DelugeVPN: Change default download directory from /data to /downloads for *arr compatibility

### DIFF
--- a/roles/delugevpn/tasks/main.yml
+++ b/roles/delugevpn/tasks/main.yml
@@ -100,3 +100,7 @@
     purge_networks: yes
     restart_policy: unless-stopped
     state: started
+
+- name: DelugeVPN Settings Tasks
+  include_tasks: "settings/main.yml"
+  when: (not continuous_integration)

--- a/roles/delugevpn/tasks/settings/main.yml
+++ b/roles/delugevpn/tasks/settings/main.yml
@@ -1,0 +1,57 @@
+#########################################################################
+# Title:            Community: DelugeVPN                                #
+# Author(s):        maximuskowalski, Migz93                             #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image(s):  binhex/arch-delugevpn                               #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+
+## Checks
+
+- name: Settings | Wait for 'core.conf' to be created
+  wait_for:
+    path: "/opt/delugevpn/core.conf"
+    state: present
+
+- name: Settings | Wait for 10 seconds before stopping delugevpn container
+  wait_for:
+    timeout: 10
+
+- name: Settings | Stop container
+  docker_container:
+    name: delugevpn
+    state: stopped
+
+## Adjusting directories
+
+- name: Settings | Set download directory
+  lineinfile:
+    path: "/opt/delugevpn/core.conf"
+    regexp: '^\s\s\s\s"download_location":\s*'
+    line: '    "download_location": "/downloads/torrents/deluge",'
+    state: present
+
+- name: Settings | Set completed directory
+  lineinfile:
+    path: "/opt/delugevpn/core.conf"
+    regexp: '^\s\s\s\s"move_completed_path":\s*'
+    line: '    "move_completed_path": "/downloads/torrents/deluge/completed",'
+    state: present
+
+- name: Settings | Set torrents directory
+  lineinfile:
+    path: "/opt/delugevpn/core.conf"
+    regexp: '^\s\s\s\s"torrentfiles_location":\s*'
+    line: '    "torrentfiles_location": "/downloads/torrents/deluge/torrents",'
+    state: present
+
+## Restart Container
+
+- name: Settings | Start container
+  docker_container:
+    name: delugevpn
+    state: started


### PR DESCRIPTION
Adding automatic configuration of download directories for DelugeVPN following ruTorrent role procedure.

This will make DelugeVPN default to `/downloads/torrents/deluge` instead of `/data/downloads`, which caused *arrs to not recognise the download directory being used by the client.

With this change DelugeVPN should work out of the box with the *arrs. However the Labels plugin still needs to be enabled by the user in order to use *arr labels. I attempted to add this in myself but implementing this elegantly without overwriting plugins with blockinfile on each run of the role is beyond my skill level at present.

There is no reason these same changes shouldn't be directly transferable to the main Deluge role that I can see. 

Also wasn't sure if the default download directory and volume binds should be changed from `/mnt/local/downloads/torrents/deluge` as they currently are on this role over to `/mnt/local/downloads/torrents/delugevpn` to keep the 2 instances separate.

Nothing about the role itself has been modified, I've simply added the extra task to modify the config file after the main task finishes. I've confirmed this working on both existing and new installs personally, have not yet had other users test the changes.

It is worth noting if people already use a custom download directory, the role will overwrite this in the same manner as running the rutorrent role.

