### PR TITLE
Added published ports for transmissionx role

### DIFF
--- a/roles/transmissionx/tasks/main.yml
+++ b/roles/transmissionx/tasks/main.yml
@@ -2,7 +2,7 @@
 # Title:            Community: TransmissionX                            #
 # Author(s):        giosann                                             #
 # URL:              https://github.com/Cloudbox/Community               #
-# Docker Image(s):  linuxserver/trasmission                             #
+# Docker Image:     linuxserver/trasmission                             #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################
@@ -28,6 +28,8 @@
   include_tasks: template.yml
   vars:
     rolename: "{{ role }}"
+    roleport: "{{ 51413 + index}}"
   with_items: "{{ transmissionx.roles }}"
   loop_control:
     loop_var: role
+    index_var: index

--- a/roles/transmissionx/tasks/main.yml
+++ b/roles/transmissionx/tasks/main.yml
@@ -1,6 +1,6 @@
 #########################################################################
 # Title:            Community: TransmissionX                            #
-# Author(s):        giosann                                             #
+# Author(s):        giosann,saltydk                                     #
 # URL:              https://github.com/Cloudbox/Community               #
 # Docker Image:     linuxserver/trasmission                             #
 # --                                                                    #

--- a/roles/transmissionx/tasks/main.yml
+++ b/roles/transmissionx/tasks/main.yml
@@ -28,7 +28,7 @@
   include_tasks: template.yml
   vars:
     rolename: "{{ role }}"
-    roleport: "{{ 51413 + index}}"
+    roleport: "{{ 51413 + index }}"
   with_items: "{{ transmissionx.roles }}"
   loop_control:
     loop_var: role

--- a/roles/transmissionx/tasks/settings/dynamic.yml
+++ b/roles/transmissionx/tasks/settings/dynamic.yml
@@ -1,0 +1,20 @@
+#########################################################################
+# Title:            Community: transmissionx | Dynamic Settings Tasks   #
+# Author(s):        giosann                                             #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image:     linuxserver/trasmission                             #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+# settings.json
+
+# Change Published Port
+- name: Settings | Dynamic | Set peer-port
+  lineinfile:
+    path: "/opt/transmission{{ rolename }}/settings.json"
+    regexp: '^\s*\"peer\-port\"\:.*'
+    line: '    "peer-port": {{ roleport }},'
+    state: present

--- a/roles/transmissionx/tasks/settings/main.yml
+++ b/roles/transmissionx/tasks/settings/main.yml
@@ -1,8 +1,8 @@
 #########################################################################
-# Title:            transmissionx: Sttings Tasks                        #
+# Title:            Community: transmissionx | Settings Tasks           #
 # Author(s):        giosann                                             #
 # URL:              https://github.com/Cloudbox/Community               #
-# Docker Image(s):  linuxserver/trasmission                             #
+# Docker Image:     linuxserver/trasmission                             #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################
@@ -30,6 +30,13 @@
 - name: Settings | transmissionx Static Settings Tasks
   include_tasks: "static.yml"
   when: (not settings_json.stat.exists)
+
+## transmissionx Dynamic Settings Tasks
+
+- name: Settings | transmissionx Dynamic Settings Tasks
+  include_tasks: "dynamic.yml"
+
+## Start container
 
 - name: Settings | Start container
   docker_container:

--- a/roles/transmissionx/tasks/settings/static.yml
+++ b/roles/transmissionx/tasks/settings/static.yml
@@ -1,15 +1,15 @@
 #########################################################################
-# Title:         ruTorrent -  Static Settings Tasks                     #
-# Author(s):     l3uddz, desimaniac                                     #
-# URL:           https://github.com/cloudbox/cloudbox                   #
-# Docker Image:  horjulf/rutorrent-autodl                               #
+# Title:            Community: transmissionx | Static Settings Tasks    #
+# Author(s):        giosann                                             #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image:     linuxserver/trasmission                             #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################
 #                   GNU General Public License v3.0                     #
 #########################################################################
 ---
-## rtorrent.rc
+# settings.json
 
 # Disable DHT - i.e. disables trackerless torrents.
 - name: Settings | Static | Disable DHT

--- a/roles/transmissionx/tasks/template.yml
+++ b/roles/transmissionx/tasks/template.yml
@@ -1,6 +1,6 @@
 #########################################################################
 # Title:            Community: TransmissionX | Template                 #
-# Author(s):        giosann                                             #
+# Author(s):        giosann,saltydk                                     #
 # URL:              https://github.com/Cloudbox/Community               #
 # Docker Image:     linuxserver/trasmission                             #
 # --                                                                    #

--- a/roles/transmissionx/tasks/template.yml
+++ b/roles/transmissionx/tasks/template.yml
@@ -82,7 +82,7 @@
   include_tasks: "settings/main.yml"
   vars:
     rolename: "{{ role }}"
-    roleport: "{{ roleport }}"
+    roleport: "{{ 51413 + index }}"
   loop_control:
     loop_var: role
     index_var: index

--- a/roles/transmissionx/tasks/template.yml
+++ b/roles/transmissionx/tasks/template.yml
@@ -2,7 +2,7 @@
 # Title:            Community: TransmissionX | Template                 #
 # Author(s):        giosann                                             #
 # URL:              https://github.com/Cloudbox/Community               #
-# Docker Image(s):  linuxserver/trasmission                             #
+# Docker Image:     linuxserver/trasmission                             #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################
@@ -51,6 +51,8 @@
     name: "transmission{{ rolename }}"
     image: "linuxserver/transmission"
     pull: yes
+    published_ports:
+      - "{{ roleport }}:{{ roleport }}"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"
@@ -80,6 +82,8 @@
   include_tasks: "settings/main.yml"
   vars:
     rolename: "{{ role }}"
+    roleport: "{{ roleport }}"
   loop_control:
     loop_var: role
+    index_var: index
   when: (not continuous_integration)


### PR DESCRIPTION
# Description

transmissionx did not have any published ports until now, because of this the client was not "connectable" from torrent trackers.
This creates a different published ports for each instance (starts from 51413 and adds 1 each time).

I've also fixed a bit of the "header" grafic and added credits to saltydk for his work on https://github.com/Cloudbox/Community/pull/273

# How Has This Been Tested?

I've tested on my already deployed role, with a total 5 instances of transmission

# New Role Checklist:

- [x] I have reviewed the [Contribute page in the wiki](https://github.com/Cloudbox/Community/wiki/Contribute)
- [x] I have updated the header in any files I may have used as templates with my own information
