### PR TITLE
Mylar3: Switch to hotio image and add migrator

### DIFF
--- a/roles/mylar3/subtasks/hotio_migration.yml
+++ b/roles/mylar3/subtasks/hotio_migration.yml
@@ -1,0 +1,28 @@
+#########################################################################
+# Title:         Community: Mylar3 | hotio Migration Tasks              #
+# Author(s):     owine                                                  #
+# URL:           https://github.com/Cloudbox/Community                  #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: hotio Migration | Check 'mylar' subfolder exists
+  stat:
+    path: "/opt/mylar3/mylar"
+  register: subfolder1
+
+- name: hotio Migration | Check 'app' subfolder exists
+  stat:
+    path: "/opt/mylar3/app"
+  register: subfolder2
+
+- name: hotio Migration | Move 'mylar3' folder contents to 'app' subfolder
+  shell: |
+    mv "/opt/mylar3/mylar" /tmp/app
+    mkdir "/opt/mylar3"
+    mv /tmp/app "/opt/mylar3/"
+    find "/opt/mylar3/*" -type d -empty -delete
+    chown -R {{ user.name }}:{{ user.name }} "/opt/mylar3"
+  when: (subfolder1.stat.exists) and not (subfolder2.stat.exists)

--- a/roles/mylar3/tasks/main.yml
+++ b/roles/mylar3/tasks/main.yml
@@ -1,8 +1,8 @@
 #########################################################################
 # Title:            Community: Mylar3                                   #
-# Author(s):        theotocopulitos                                     #
+# Author(s):        theotocopulitos,owine                               #
 # URL:              https://github.com/Cloudbox/Community               #
-# Docker Image(s):  ajslater/mylar3                                     #
+# Docker Image(s):  hotio/mylar3                                        #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################

--- a/roles/mylar3/tasks/main.yml
+++ b/roles/mylar3/tasks/main.yml
@@ -21,6 +21,9 @@
     name: mylar3
     state: absent
 
+- name: Hotio Migration Tasks
+  import_tasks: "subtasks/hotio_migration.yml"
+
 - name: Create mylar3 directories
   file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }}"
   with_items:
@@ -30,11 +33,12 @@
 - name: Create and start container
   docker_container:
     name: mylar3
-    image: ajslater/mylar3
+    image: hotio/mylar3
     pull: yes
     env:
       PUID: "{{ uid }}"
       PGID: "{{ gid }}"
+      TZ: "{{ tz }}"
       VIRTUAL_HOST: "mylar3.{{ user.domain }}"
       VIRTUAL_PORT: "8090"
       LETSENCRYPT_HOST: "mylar3.{{ user.domain }}"
@@ -44,8 +48,6 @@
       - "/mnt/local/downloads:/downloads"
       - "/mnt/unionfs/Media/Comics:/comics"
       - "/mnt:/mnt"
-      - "/etc/timezone:/etc/timezone:ro"
-      - "/etc/localtime:/etc/localtime:ro"
     labels:
       "com.github.cloudbox.cloudbox_managed": "true"
     networks:


### PR DESCRIPTION
# Description

Change `mylar3` image to `hotio/mylar3` and add migrator for config path changes

# How Has This Been Tested?

Tested clean deploy as well as migration with latest `develop`

# New Role Checklist:

- [x] I have reviewed the [Contribute page in the wiki](https://github.com/Cloudbox/Community/wiki/Contribute)
- [x] I have updated the header in any files I may have used as templates with my own information
- [n/a] I have added my new role to `appveyor.yml`
- [n/a] I have added my new role to `community.yml`
- [x] I have verified that any Docker images used are current and supported.
- [n/a] I have made corresponding changes to the documentation

Fixes #256 