### PR TITLE
Tdarr pinned to 1.3003 release

### DIFF
--- a/ansible_facts.d/group.fact
+++ b/ansible_facts.d/group.fact
@@ -1,29 +1,24 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # https://github.com/ifor2u/specbase
 
-import sys
 import json
-import subprocess
 
-cmd = "cat /etc/group"
-
-p = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE,stderr=subprocess.STDOUT, close_fds=True)
-(stdouterr, stdin) = (p.stdout, p.stdin)
+file = open("/etc/group", "r+")
 
 list = {}
 while True:
-  line = stdouterr.readline()
-  if not line:
-    break
-  tokens = line.rstrip().split(":")
-  group = {}
-  group["gid"] = tokens[2]
-  group["group-list"] = []
-  if len(tokens) == 4:
-    for token in tokens[3].split(","):
-        if token == "":
-          break
-        group["group-list"].append(token)
-  list[tokens[0]] = group
+    line = file.readline()
+    if not line:
+        break
+    tokens = line.rstrip().split(":")
+    group = {}
+    group["gid"] = tokens[2]
+    group["group-list"] = []
+    if len(tokens) == 4:
+        for token in tokens[3].split(","):
+            if token == "":
+                break
+            group["group-list"].append(token)
+    list[tokens[0]] = group
 
-print json.dumps(list)
+print(json.dumps(list))

--- a/ansible_facts.d/user.fact
+++ b/ansible_facts.d/user.fact
@@ -1,18 +1,13 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # https://github.com/ifor2u/specbase
 
-import sys
 import json
-import subprocess
 
-cmd = "cat /etc/passwd"
-
-p = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE,stderr=subprocess.STDOUT, close_fds=True)
-(stdouterr, stdin) = (p.stdout, p.stdin)
+file = open("/etc/passwd", "r+")
 
 list = {}
 while True:
-  line = stdouterr.readline()
+  line = file.readline()
   if not line:
     break
   tokens = line.rstrip().split(":")
@@ -24,4 +19,4 @@ while True:
   user["shell"] = tokens[6]
   list[tokens[0]] = user
 
-print json.dumps(list)
+print(json.dumps(list))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,6 +84,7 @@ environment:
     plex2
     pyload
     qbittorrent
+    qbittorrentvpn
     quassel
     radarrx
     redbot

--- a/community.yml
+++ b/community.yml
@@ -84,6 +84,7 @@
     - { role: plex2, tags: ['plex2'] }
     - { role: pyload, tags: ['pyload'] }
     - { role: qbittorrent, tags: ['qbittorrent'] }
+    - { role: qbittorrentvpn, tags: ['qbittorrentvpn'] }
     - { role: quassel, tags: ['quassel'] }
     - { role: radarrx, tags: ['radarrx'] }
     - { role: redbot, tags: ['redbot'] }

--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -40,6 +40,12 @@ navidrome:
 ombix: 
   roles: 
     - 4k
+qbittorrentvpn:
+  vpn_endpoint: netherlands.ovpn
+  vpn_user: your_vpn_username
+  vpn_pass: your_vpn_password
+  vpn_prov: pia
+  vpn_client: wireguard # 'wireguard' or 'openvpn'
 radarrx: 
   roles: 
     - 1080webdl
@@ -59,7 +65,7 @@ synclounge:
   domain: ~
   subdomain: synclounge
 transmissionvpn: 
-  vpn_endpoint: Netherlands.ovpn
+  vpn_endpoint: netherlands.ovpn
   vpn_pass: your_vpn_password
   vpn_prov: NORDVPN
   vpn_user: your_vpn_username

--- a/roles/airdcpp/tasks/main.yml
+++ b/roles/airdcpp/tasks/main.yml
@@ -68,8 +68,6 @@
     image: "gangefors/airdcpp-webclient"
     pull: yes
     published_ports:
-      - "127.0.0.1:2617:5600"
-      - "127.0.0.1:7327:5601"
       - "21248:21248"
       - "21248:21248/udp"
       - "21249:21249"

--- a/roles/bitwarden/tasks/main.yml
+++ b/roles/bitwarden/tasks/main.yml
@@ -51,13 +51,10 @@
     name: bitwarden
     image: bitwardenrs/server:latest
     pull: yes
-    published_ports:
-      - "127.0.0.1:6423:6423"
     env:
       TZ: "{{ tz }}"
-      ROCKET_PORT: "6423"
       VIRTUAL_HOST: "bitwarden.{{ user.domain }}"
-      VIRTUAL_PORT: "6423"
+      VIRTUAL_PORT: "80"
       LETSENCRYPT_HOST: "bitwarden.{{ user.domain }}"
       LETSENCRYPT_EMAIL: "{{ user.email }}"
     volumes:

--- a/roles/bitwarden/tasks/main.yml
+++ b/roles/bitwarden/tasks/main.yml
@@ -51,10 +51,13 @@
     name: bitwarden
     image: bitwardenrs/server:latest
     pull: yes
+    published_ports:
+      - "127.0.0.1:6423:6423"
     env:
       TZ: "{{ tz }}"
+      ROCKET_PORT: "6423"
       VIRTUAL_HOST: "bitwarden.{{ user.domain }}"
-      VIRTUAL_PORT: "80"
+      VIRTUAL_PORT: "6423"
       LETSENCRYPT_HOST: "bitwarden.{{ user.domain }}"
       LETSENCRYPT_EMAIL: "{{ user.email }}"
     volumes:

--- a/roles/bookstack/tasks/main.yml
+++ b/roles/bookstack/tasks/main.yml
@@ -9,11 +9,6 @@
 #                   GNU General Public License v3.0                     #
 #########################################################################
 ---
-- name: Install required packages
-  apt: "name={{ item }} state=latest"
-  with_items:
-    - python-pymysql
-
 - name: MariaDB Role
   include_role:
     name: mariadb
@@ -33,12 +28,9 @@
   with_items:
     - bookstack
 
-- name: Create bookstack database
-  mysql_db:
-    name: bookstackapp
-    login_user: root
-    login_password: password321
-    state: present
+- name: "Create bookstackapp database"
+  command: "docker exec mariadb mysql -u root -ppassword321 -e 'create schema bookstackapp DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'"
+  ignore_errors: yes
 
 - name: Create required directories
   file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }}"
@@ -50,8 +42,6 @@
     name: bookstack
     image: "linuxserver/bookstack"
     pull: yes
-    published_ports:
-      - "127.0.0.1:6875:443"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"

--- a/roles/bookstack/tasks/main.yml
+++ b/roles/bookstack/tasks/main.yml
@@ -46,6 +46,7 @@
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"
       PGID: "{{ gid }}"
+      APP_URL: "https://{{ bookstack.subdomain|default('bookstack',true) }}.{{ user.domain }}"
       DB_HOST: "mariadb:3306"
       DB_USER: root
       DB_PASS: password321

--- a/roles/calibre-web/tasks/main.yml
+++ b/roles/calibre-web/tasks/main.yml
@@ -31,8 +31,6 @@
     name: calibre-web
     image: linuxserver/calibre-web
     pull: yes
-    published_ports:
-      - "127.0.0.1:8083:8083"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"

--- a/roles/calibre/tasks/main.yml
+++ b/roles/calibre/tasks/main.yml
@@ -32,9 +32,6 @@
     name: calibre
     image: linuxserver/calibre
     pull: yes
-    published_ports:
-      - "127.0.0.1:8087:8080"
-      - "127.0.0.1:8088:8081"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"
@@ -56,6 +53,9 @@
       - name: cloudbox
         aliases:
           - calibre
+    exposed_ports:
+      - 8080
+      - 8081
     purge_networks: yes
     restart_policy: unless-stopped
     state: started

--- a/roles/comicstreamer/tasks/main.yml
+++ b/roles/comicstreamer/tasks/main.yml
@@ -32,8 +32,6 @@
     name: comicstreamer
     image: kalinon/comicstreamer
     pull: yes
-    published_ports:
-      - "32500:32500"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"

--- a/roles/comixed/tasks/main.yml
+++ b/roles/comixed/tasks/main.yml
@@ -1,8 +1,8 @@
 #########################################################################
-# Title:            Community: comixed                                #
+# Title:            Community: comixed                                  #
 # Author(s):        theotocopulitos                                     #
 # URL:              https://github.com/Cloudbox/Community               #
-# Docker Image(s):  comixed/comixed                               #
+# Docker Image(s):  comixed/comixed                                     #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################
@@ -31,8 +31,6 @@
     name: comixed
     image: comixed/comixed:latest
     pull: yes
-    published_ports:
-      - "7171:7171"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"

--- a/roles/deezloader-remix/tasks/main.yml
+++ b/roles/deezloader-remix/tasks/main.yml
@@ -43,8 +43,6 @@
     name: deezloader
     image: "bocki/deezloaderrmx"
     pull: yes
-    published_ports:
-      - "127.0.0.1:1730:1730"
     env:
       BACKUP: "yes"
       VIRTUAL_HOST: "deezloader.{{ user.domain }}"

--- a/roles/delugevpn/tasks/main.yml
+++ b/roles/delugevpn/tasks/main.yml
@@ -39,7 +39,7 @@
   with_items:
     - "ca.rsa.2048.crt"
     - "crl.rsa.2048.pem"
-    - "{{ delugevpn.vpn_endpoint|default('Netherlands.ovpn',true) }}"
+    - "{{ delugevpn.vpn_endpoint|default('netherlands.ovpn',true) }}"
 
 - name: Create new downloads directories
   file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }} recurse=yes"

--- a/roles/filebot/tasks/main.yml
+++ b/roles/filebot/tasks/main.yml
@@ -31,8 +31,6 @@
     name: filebot
     image: jlesage/filebot
     pull: yes
-    published_ports:
-      - "127.0.0.1:5801:5800"
     env:
       TZ: "{{ tz }}"
       USER_ID: "{{ uid }}"
@@ -53,6 +51,8 @@
       - name: cloudbox
         aliases:
           - filebot
+    exposed_ports:
+      - 5800
     purge_networks: yes
     restart_policy: unless-stopped
     state: started

--- a/roles/filebrowser/tasks/main.yml
+++ b/roles/filebrowser/tasks/main.yml
@@ -61,8 +61,6 @@
     name: filebrowser
     image: filebrowser/filebrowser:latest
     pull: yes
-    published_ports:
-      - "127.0.0.1:6469:1216"
     env:
       TZ: "{{ tz }}"
       VIRTUAL_HOST: "filebrowser.{{ user.domain }}"
@@ -80,5 +78,7 @@
       - name: cloudbox
         aliases:
           - filebrowser
+    exposed_ports:
+      - 1216
     restart_policy: unless-stopped
     state: started

--- a/roles/filezilla/tasks/main.yml
+++ b/roles/filezilla/tasks/main.yml
@@ -47,7 +47,6 @@
       TZ: "{{ tz }}"
       USER_ID: "{{ uid }}"
       GROUP_ID: "{{ gid }}"
-      UMASK: "664"
       KEEP_APP_RUNNING: "1"
       VIRTUAL_HOST: "filezilla.{{ user.domain }}"
       VIRTUAL_PORT: "5800"

--- a/roles/gazee/tasks/main.yml
+++ b/roles/gazee/tasks/main.yml
@@ -32,8 +32,6 @@
     name: gazee
     image: linuxserver/gazee
     pull: yes
-    published_ports:
-      - "127.0.0.1:4242:4242"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"

--- a/roles/gitea/tasks/main.yml
+++ b/roles/gitea/tasks/main.yml
@@ -9,11 +9,6 @@
 #                   GNU General Public License v3.0                     #
 #########################################################################
 ---
-- name: Install required packages
-  apt: "name={{ item }} state=latest"
-  with_items:
-    - python-pymysql
-
 - name: MariaDB Role
   include_role:
     name: mariadb
@@ -33,12 +28,9 @@
   with_items:
     - gitea
 
-- name: Create gitea database
-  mysql_db:
-    name: gitea
-    login_user: root
-    login_password: password321
-    state: present
+- name: "Create gitea database"
+  command: "docker exec mariadb mysql -u root -ppassword321 -e 'create schema gitea DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'"
+  ignore_errors: yes
 
 - name: Create required directories
   file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }}"
@@ -50,8 +42,6 @@
     name: gitea
     image: "gitea/gitea:latest"
     pull: yes
-    published_ports:
-      - "127.0.0.1:3000:3000"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"

--- a/roles/glances/tasks/main.yml
+++ b/roles/glances/tasks/main.yml
@@ -56,7 +56,7 @@
 - name: Create and start container
   docker_container:
     name: glances
-    image: "satzisa/glances"
+    image: "nicolargo/glances"
     pull: yes
     env:
       TZ: "{{ tz }}"
@@ -74,6 +74,7 @@
       - name: cloudbox
         aliases:
           - glances
+    pid_mode: host
     purge_networks: yes
     restart_policy: unless-stopped
     state: started

--- a/roles/goplaxt/tasks/main.yml
+++ b/roles/goplaxt/tasks/main.yml
@@ -31,8 +31,6 @@
     name: goplaxt
     image: xanderstrike/goplaxt
     pull: yes
-    published_ports:
-      - "127.0.0.1:8000:8000"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"

--- a/roles/guacamole/tasks/main.yml
+++ b/roles/guacamole/tasks/main.yml
@@ -33,6 +33,8 @@
     image: jasonbean/guacamole:latest
     pull: yes
     env:
+      PUID: "{{ uid }}"
+      PGID: "{{ gid }}"
       TZ: "{{ tz }}"
       VIRTUAL_HOST: "guacamole.{{ user.domain }}"
       VIRTUAL_PORT: "8080"

--- a/roles/handbrake/tasks/main.yml
+++ b/roles/handbrake/tasks/main.yml
@@ -36,8 +36,6 @@
     name: handbrake
     image: jlesage/handbrake
     pull: yes
-    published_ports:
-      - "127.0.0.1:6900:5800"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"
@@ -60,6 +58,8 @@
       - name: cloudbox
         aliases:
           - handbrake
+    exposed_ports:
+      - 5800
     purge_networks: yes
     restart_policy: unless-stopped
     state: started

--- a/roles/heimdall/tasks/main.yml
+++ b/roles/heimdall/tasks/main.yml
@@ -42,8 +42,6 @@
     name: heimdall
     image: linuxserver/heimdall
     pull: yes
-    published_ports:
-      - "127.0.0.1:8078:443"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"

--- a/roles/invoiceninja/tasks/main.yml
+++ b/roles/invoiceninja/tasks/main.yml
@@ -13,8 +13,8 @@
   include_role:
     name: mariadb
 
-- name: "sleep for 20 seconds and continue"
-  wait_for: timeout=20
+- name: "sleep for 120 seconds and continue"
+  wait_for: timeout=120
 
 - name: "Set DNS Record on CloudFlare"
   include_role:

--- a/roles/jdownloader2/tasks/main.yml
+++ b/roles/jdownloader2/tasks/main.yml
@@ -55,9 +55,6 @@
     name: jdownloader2
     image: "jlesage/jdownloader-2:latest"
     pull: yes
-    published_ports:
-      - "127.0.0.1:5800:5800"
-      - "127.0.0.1:5900:5900"
     env:
       TZ: "{{ tz }}"
       VIRTUAL_HOST: "jdownloader2.{{ user.domain }}"
@@ -81,6 +78,8 @@
       - name: cloudbox
         aliases:
           - jdownloader2
+    exposed_ports:
+      - 5800
     purge_networks: yes
     restart_policy: unless-stopped
     state: started

--- a/roles/jirafeau/tasks/main.yml
+++ b/roles/jirafeau/tasks/main.yml
@@ -32,8 +32,6 @@
     name: jirafeau
     image: "jgeusebroek/jirafeau"
     pull: yes
-    published_ports:
-      - "127.0.0.1:6234:80"
     env:
       TZ: "{{ tz }}"
       VIRTUAL_HOST: "jirafeau.{{ jirafeau.domain | default(user.domain,true) }}"

--- a/roles/kitana/tasks/main.yml
+++ b/roles/kitana/tasks/main.yml
@@ -31,8 +31,6 @@
     name: kitana
     image: "pannal/kitana:latest"
     pull: yes
-    published_ports:
-      - "127.0.0.1:31337:31337"
     env:
       TZ: "{{ tz }}"
       VIRTUAL_HOST: "kitana.{{ user.domain }}"

--- a/roles/lazylibrarian/tasks/main.yml
+++ b/roles/lazylibrarian/tasks/main.yml
@@ -31,8 +31,6 @@
     name: lazylibrarian
     image: thraxis/lazylibrarian-calibre
     pull: yes
-    published_ports:
-      - "127.0.0.1:5299:5299"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -24,8 +24,6 @@
     name: mariadb
     image: "linuxserver/mariadb"
     pull: yes
-    published_ports:
-      - "127.0.0.1:3306:3306"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"

--- a/roles/mediabutler/tasks/main.yml
+++ b/roles/mediabutler/tasks/main.yml
@@ -57,8 +57,6 @@
     name: "mediabutler"
     image: "mediabutler/server"
     pull: yes
-    published_ports:
-      - "0.0.0.0:9876:9876"
     env:
       TZ: "{{ tz }}"
       UID: "{{ uid }}"

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -13,6 +13,9 @@
   include_role:
     name: mariadb
 
+- name: "sleep for 120 seconds and continue"
+  wait_for: timeout=120
+
 - name: "Set DNS Record on CloudFlare"
   include_role:
     name: cloudflare-dns

--- a/roles/nowshowing/tasks/main.yml
+++ b/roles/nowshowing/tasks/main.yml
@@ -31,8 +31,6 @@
     name: nowshowing
     image: ninthwalker/nowshowing:v2
     pull: yes
-    published_ports:
-      - "127.0.0.1:6878:6878"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"

--- a/roles/ombix/tasks/template.yml
+++ b/roles/ombix/tasks/template.yml
@@ -37,7 +37,7 @@
       UMASK: "002"
       VIRTUAL_HOST: "ombi{{ rolename }}.{{ user.domain }}"
       VIRTUAL_PORT: "5000"
-      LETSENCRYPT_HOST: "{{ ombi.subdomain|default('ombi',true) }}.{{ user.domain }}"
+      LETSENCRYPT_HOST: "ombi{{ rolename }}.{{ user.domain }}"
       LETSENCRYPT_EMAIL: "{{ user.email }}"
       LC_ALL: "en_US.UTF-8"
       TZ: "{{ tz }}"

--- a/roles/qbittorrentvpn/tasks/main.yml
+++ b/roles/qbittorrentvpn/tasks/main.yml
@@ -1,0 +1,98 @@
+#########################################################################
+# Title:            Cloudbox Community: qbittorrentvpn                  #
+# Author(s):        bonny1992                                           #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image(s):  binhex/arch-qbittorrentvpn                          #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+- name: "Setting CloudFlare DNS Record"
+  include_role:
+    name: cloudflare-dns
+  vars:
+    record: qbittorrentvpn
+  when: cloudflare_enabled
+
+- name: Stop and remove any existing container
+  docker_container:
+    name: qbittorrentvpn
+    state: absent
+
+- name: Create qbittorrentvpn directories
+  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }}"
+  with_items:
+    - /opt/qbittorrentvpn
+    - /opt/qbittorrentvpn/openvpn
+    - /opt/qbittorrentvpn/piaconfigs
+
+- name: Get the OpenVPN configuration files and certs (next gen)
+  unarchive:
+    src: https://www.privateinternetaccess.com/openvpn/openvpn.zip
+    dest: /opt/qbittorrentvpn/piaconfigs
+    remote_src: yes
+
+- name: Copy Cert and config
+  copy: "src=/opt/qbittorrentvpn/piaconfigs/{{ item }} dest=/opt/qbittorrentvpn/openvpn"
+  with_items:
+    - "ca.rsa.2048.crt"
+    - "crl.rsa.2048.pem"
+    - "{{ qbittorrentvpn.vpn_endpoint|default('Netherlands.ovpn',true) }}"
+
+- name: Create new downloads directories
+  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }} recurse=yes"
+  with_items:
+    - "{{ downloads.torrents }}"
+    - "{{ downloads.torrents }}/qbittorrentvpn"
+    - "{{ downloads.torrents }}/qbittorrentvpn/completed"
+    - "{{ downloads.torrents }}/qbittorrentvpn/incoming"
+    - "{{ downloads.torrents }}/qbittorrentvpn/watched"
+
+- name: Set default_volumes variable
+  set_fact:
+    default_volumes:
+      - "/opt/qbittorrentvpn:/config"
+      - "/opt/scripts:/scripts"
+      - "/mnt:/mnt"
+
+- name: Create and start container
+  docker_container:
+    name: qbittorrentvpn
+    image: binhex/arch-qbittorrentvpn
+    pull: yes
+    privileged: true
+    sysctls:
+      net.ipv4.conf.all.src_valid_mark: 1
+    capabilities: NET_ADMIN
+    env:
+      TZ: "{{ tz }}"
+      PUID: "{{ uid }}"
+      PGID: "{{ gid }}"
+      VIRTUAL_HOST: "qbittorrentvpn.{{ user.domain }}"
+      VIRTUAL_PORT: "8080"
+      LETSENCRYPT_HOST: "qbittorrentvpn.{{ user.domain }}"
+      LETSENCRYPT_EMAIL: "{{ user.email }}"
+      UMASK_SET: "022"
+      VPN_ENABLED: "yes"
+      VPN_USER: "{{ qbittorrentvpn.vpn_user|default('username',true) }}"
+      VPN_PASS: "{{ qbittorrentvpn.vpn_pass|default('password',true) }}"
+      VPN_PROV: "{{ qbittorrentvpn.vpn_prov|default('pia',true) }}"
+      VPN_CLIENT: "{{ qbittorrentvpn.vpn_client|default('openvpn', 'openvpn') }}"
+      STRICT_PORT_FORWARD: "yes"
+      ENABLE_PRIVOXY: "no"
+      LAN_NETWORK: "172.18.0.1/16"
+      NAME_SERVERS: "209.222.18.222,84.200.69.80,37.235.1.174,1.1.1.1,209.222.18.218,37.235.1.177,84.200.70.40,1.0.0.1"
+      PHP_TZ: "{{ tz }}"
+      WEBUI_PORT: "8080"
+      DEBUG: "false"
+    volumes: "{{ default_volumes + torrents_downloads_path|default([]) }}"
+    labels:
+      "com.github.cloudbox.cloudbox_managed": "true"
+    networks:
+      - name: cloudbox
+        aliases:
+          - qbittorrentvpn
+    purge_networks: yes
+    restart_policy: unless-stopped
+    state: started

--- a/roles/requestrrx/tasks/template.yml
+++ b/roles/requestrrx/tasks/template.yml
@@ -13,6 +13,11 @@
   debug:
     msg: "Installing {{ rolename }}"
 
+- name: Stop and remove any existing container
+  docker_container:
+    name: "requestrr{{ rolename }}"
+    state: absent
+
 - name: "Set DNS Record on CloudFlare"
   include_role:
     name: cloudflare-dns

--- a/roles/resilio-sync/tasks/main.yml
+++ b/roles/resilio-sync/tasks/main.yml
@@ -35,7 +35,6 @@
     image: "resilio/sync"
     pull: yes
     published_ports:
-      - "127.0.0.1:8888:8888"
       - "55555:55555"
     user: "{{ uid }}:{{ gid }}"
     env:

--- a/roles/sshwifty/tasks/main.yml
+++ b/roles/sshwifty/tasks/main.yml
@@ -51,8 +51,6 @@
     volumes:
       - "/opt/sshwifty/config:/config"
       - "/mnt:/mnt"
-    ports:
-      - 127.0.0.1:8182:8182
     labels:
       "com.github.cloudbox.cloudbox_managed": "true"
     networks:

--- a/roles/stash/tasks/main.yml
+++ b/roles/stash/tasks/main.yml
@@ -31,8 +31,6 @@
     name: stash
     image: stashapp/stash:development-x86_64
     pull: yes
-    published_ports:
-      - "127.0.0.1:9999:9999"
     env:
       TZ: "{{ tz }}"
       UID: "{{ uid }}"

--- a/roles/subsonic/tasks/main.yml
+++ b/roles/subsonic/tasks/main.yml
@@ -31,8 +31,6 @@
     name: subsonic
     image: theultimatecoder/subsonic
     pull: yes
-    published_ports:
-      - "127.0.0.1:4041:4040"
     env:
       TZ: "{{ tz }}"
       SUBSONIC_UID: "{{ uid }}"

--- a/roles/tdarr/tasks/main.yml
+++ b/roles/tdarr/tasks/main.yml
@@ -47,7 +47,7 @@
 - name: Create and start container
   docker_container:
     name: tdarr
-    image: haveagitgat/tdarr
+    image: haveagitgat/tdarr:1.3003
     pull: yes
     env:
       TZ: "{{ tz }}"

--- a/roles/tdarr/tasks/main.yml
+++ b/roles/tdarr/tasks/main.yml
@@ -49,8 +49,6 @@
     name: tdarr
     image: haveagitgat/tdarr
     pull: yes
-    published_ports:
-      - "127.0.0.1:8265:8265"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"

--- a/roles/thelounge/tasks/main.yml
+++ b/roles/thelounge/tasks/main.yml
@@ -31,8 +31,6 @@
     name: thelounge
     image: "linuxserver/thelounge"
     pull: yes
-    published_ports:
-      - "127.0.0.1:9500:9000"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"

--- a/roles/transmissionx/tasks/main.yml
+++ b/roles/transmissionx/tasks/main.yml
@@ -1,8 +1,8 @@
 #########################################################################
 # Title:            Community: TransmissionX                            #
-# Author(s):        giosann                                             #
+# Author(s):        giosann,saltydk                                     #
 # URL:              https://github.com/Cloudbox/Community               #
-# Docker Image(s):  linuxserver/trasmission                             #
+# Docker Image:     linuxserver/trasmission                             #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################
@@ -28,6 +28,8 @@
   include_tasks: template.yml
   vars:
     rolename: "{{ role }}"
+    roleport: "{{ 51413 + index }}"
   with_items: "{{ transmissionx.roles }}"
   loop_control:
     loop_var: role
+    index_var: index

--- a/roles/transmissionx/tasks/settings/dynamic.yml
+++ b/roles/transmissionx/tasks/settings/dynamic.yml
@@ -1,0 +1,20 @@
+#########################################################################
+# Title:            Community: transmissionx | Dynamic Settings Tasks   #
+# Author(s):        giosann                                             #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image:     linuxserver/trasmission                             #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+# settings.json
+
+# Change Published Port
+- name: Settings | Dynamic | Set peer-port
+  lineinfile:
+    path: "/opt/transmission{{ rolename }}/settings.json"
+    regexp: '^\s*\"peer\-port\"\:.*'
+    line: '    "peer-port": {{ roleport }},'
+    state: present

--- a/roles/transmissionx/tasks/settings/main.yml
+++ b/roles/transmissionx/tasks/settings/main.yml
@@ -1,8 +1,8 @@
 #########################################################################
-# Title:            transmissionx: Sttings Tasks                        #
+# Title:            Community: transmissionx | Settings Tasks           #
 # Author(s):        giosann                                             #
 # URL:              https://github.com/Cloudbox/Community               #
-# Docker Image(s):  linuxserver/trasmission                             #
+# Docker Image:     linuxserver/trasmission                             #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################
@@ -30,6 +30,13 @@
 - name: Settings | transmissionx Static Settings Tasks
   include_tasks: "static.yml"
   when: (not settings_json.stat.exists)
+
+## transmissionx Dynamic Settings Tasks
+
+- name: Settings | transmissionx Dynamic Settings Tasks
+  include_tasks: "dynamic.yml"
+
+## Start container
 
 - name: Settings | Start container
   docker_container:

--- a/roles/transmissionx/tasks/settings/static.yml
+++ b/roles/transmissionx/tasks/settings/static.yml
@@ -1,15 +1,15 @@
 #########################################################################
-# Title:         ruTorrent -  Static Settings Tasks                     #
-# Author(s):     l3uddz, desimaniac                                     #
-# URL:           https://github.com/cloudbox/cloudbox                   #
-# Docker Image:  horjulf/rutorrent-autodl                               #
+# Title:            Community: transmissionx | Static Settings Tasks    #
+# Author(s):        giosann                                             #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image:     linuxserver/trasmission                             #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################
 #                   GNU General Public License v3.0                     #
 #########################################################################
 ---
-## rtorrent.rc
+# settings.json
 
 # Disable DHT - i.e. disables trackerless torrents.
 - name: Settings | Static | Disable DHT

--- a/roles/transmissionx/tasks/template.yml
+++ b/roles/transmissionx/tasks/template.yml
@@ -1,8 +1,8 @@
 #########################################################################
 # Title:            Community: TransmissionX | Template                 #
-# Author(s):        giosann                                             #
+# Author(s):        giosann,saltydk                                     #
 # URL:              https://github.com/Cloudbox/Community               #
-# Docker Image(s):  linuxserver/trasmission                             #
+# Docker Image:     linuxserver/trasmission                             #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################
@@ -51,6 +51,8 @@
     name: "transmission{{ rolename }}"
     image: "linuxserver/transmission"
     pull: yes
+    published_ports:
+      - "{{ roleport }}:{{ roleport }}"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"
@@ -80,6 +82,8 @@
   include_tasks: "settings/main.yml"
   vars:
     rolename: "{{ role }}"
+    roleport: "{{ 51413 + index }}"
   loop_control:
     loop_var: role
+    index_var: index
   when: (not continuous_integration)

--- a/roles/unmanic/tasks/main.yml
+++ b/roles/unmanic/tasks/main.yml
@@ -32,8 +32,6 @@
     name: unmanic
     image: josh5/unmanic:latest
     pull: yes
-    published_ports:
-      - "127.0.0.1:8888:8888"
     env:
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"
@@ -53,6 +51,8 @@
       - name: cloudbox
         aliases:
           - unmanic
+    exposed_ports:
+      - 8888
     purge_networks: yes
     restart_policy: unless-stopped
     state: started

--- a/roles/wallabag/tasks/main.yml
+++ b/roles/wallabag/tasks/main.yml
@@ -43,8 +43,6 @@
       LETSENCRYPT_HOST: "bag.{{ user.domain }}"
       LETSENCRYPT_EMAIL: "{{ user.email }}"
       SYMFONY__ENV__DOMAIN_NAME: "https://bag.{{ user.domain }}"
-    ports:
-      - "127.0.0.1:7780:80"
     volumes:
       - "/opt/wallabag/data:/var/www/wallabag/data:rw"
       - "/opt/wallabag/images:/var/www/wallabag/web/assets/images:rw"

--- a/roles/znc/tasks/main.yml
+++ b/roles/znc/tasks/main.yml
@@ -32,7 +32,6 @@
     image: horjulf/docker-znc
     pull: yes
     published_ports:
-      - "127.0.0.1:6501:6501"
       - "6502:6502"
     env:
       TZ: "{{ tz }}"


### PR DESCRIPTION
# Description

On Sunday 31st Jan, this container (tdarr:latest) will be replaced with Tdarr v2. To keep using this exact container, use tag 1.3003.
If you're coming from V1, unfortunately V2 uses a new database and there have been a lot of changes so you'll need to start fresh.
More info: http://tdarr.io/docs/

# How Has This Been Tested?

- [x] Tested container creation by running the tag 
- [X] Check version in webinterface 
- [x] Had it transcode a video file
