### PR TITLE
Tdarr pinned to 1.3003 release

### DIFF
--- a/roles/tdarr/tasks/main.yml
+++ b/roles/tdarr/tasks/main.yml
@@ -47,7 +47,7 @@
 - name: Create and start container
   docker_container:
     name: tdarr
-    image: haveagitgat/tdarr
+    image: haveagitgat/tdarr:1.3003
     pull: yes
     env:
       TZ: "{{ tz }}"


### PR DESCRIPTION
# Description

On Sunday 31st Jan, this container (tdarr:latest) will be replaced with Tdarr v2. To keep using this exact container, use tag 1.3003.
If you're coming from V1, unfortunately V2 uses a new database and there have been a lot of changes so you'll need to start fresh.
More info: http://tdarr.io/docs/

The update to V2 will break old and new installs due to internal path changes in the container, making the current volume-mappings inadequate.  The server data (database, samples, plugins etc) is now stored in '/app/server'

 V2 also uses an additional container for the actual processing of the workload (tdarr_node)

# How Has This Been Tested?

- [x] Tested container creation by running the tag 
- [X] Check version in webinterface 
- [x] Had it transcode a video file
