### PR TITLE
Override the default downloads mount with a Cloudbox path

### DIFF
--- a/roles/deemix/tasks/main.yml
+++ b/roles/deemix/tasks/main.yml
@@ -25,6 +25,7 @@
   file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }} recurse=yes"
   with_items:
     - /opt/deemix/
+    - /mnt/local/downloads/deezer
 
 - name: Create and start container
   docker_container:
@@ -44,7 +45,7 @@
     volumes:
       - "/mnt:/mnt"
       - "/opt/deemix:/config"
-      - "/mnt/unionfs/downloads/deezer:/downloads:rw"
+      - "/mnt/local/downloads/deezer:/downloads"
     labels:
       "com.github.cloudbox.cloudbox_managed": "true"
     networks:

--- a/roles/deemix/tasks/main.yml
+++ b/roles/deemix/tasks/main.yml
@@ -44,6 +44,7 @@
     volumes:
       - "/mnt:/mnt"
       - "/opt/deemix:/config"
+      - "/mnt/unionfs/downloads/deezer:/downloads:rw"
     labels:
       "com.github.cloudbox.cloudbox_managed": "true"
     networks:


### PR DESCRIPTION
Needs a proper mount for downloads. By default the app sends downloads to `/downloads` which points to something like `/var/lib/docker/volumes/f2c8324c2aaffb5d81a0f6ea70110cb180d96caa6be1c6f5941d4577cf71d4f9/_data` inside the container.