### PR TITLE
Added Changedetection.io service

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Community Repository for Unofficial Cloudbox Add-ons
 - **[bookstack](../../wiki/Bookstack)** - [BookStack](https://www.bookstackapp.com/) Self-hosted platform for organising and storing information.
 - **[calibre-rdp](../../wiki/Calibre-RDP-and-Calibre-WEB)** - [Calibre-RDP](https://github.com/cgspeck/docker-rdp-calibre) Media path set to `/Media/Books` - a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.
 - **[calibre-web](../../wiki/Calibre-RDP-and-Calibre-WEB)** - [Calibre-RDP](https://github.com/janeczku/calibre-web) Loads opt/calibre - a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.
+- **[changedetection.io](https://github.com/dgtlmoon/changedetection.io)** - Self-hosted change monitoring of web pages.
 - **[comixed](https://github.com/mcpierce/comixed/tree/develop/docker)** - comics server and online reader
 - **[comicstreamer](https://github.com/beville/ComicStreamer)** - comics server and online reader (old, unmaintained, but fast and efficient)
 - **[CouchPotato](https://couchpota.to)** - Movie manager

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,7 @@ environment:
     btrfsmaintenance
     calibre
     calibre-web
+    changedetection
     comicstreamer
     couchpotato
     coder

--- a/community.yml
+++ b/community.yml
@@ -29,6 +29,7 @@
     - { role: btrfsmaintenance, tags: ['btrfsmaintenance'] }
     - { role: calibre, tags: ['calibre'] }
     - { role: calibre-web, tags: ['calibre-web'] }
+    - { role: changedetection, tags: ['changedetection'] }
     - { role: coder, tags: ['coder'] }
     - { role: comixed, tags: ['comixed'] }
     - { role: comicstreamer, tags: ['comicstreamer'] }

--- a/roles/changedetection/tasks/main.yml
+++ b/roles/changedetection/tasks/main.yml
@@ -1,0 +1,64 @@
+#########################################################################
+# Title:            Community: Changedetection.io                       #
+# Author(s):        mariosemes                                          #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image(s):  dgtlmoon/changedetection.io                         #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: "Set DNS Record on CloudFlare"
+  include_role:
+    name: cloudflare-dns
+  vars:
+    record: changedetection
+  when: cloudflare_enabled
+
+- name: Stop and remove any existing container
+  docker_container:
+    name: changedetection
+    state: absent
+
+- name: Create htpasswd
+  htpasswd:
+    path: "/opt/nginx-proxy/htpasswd/{{ item }}.{{ user.domain }}"
+    name: "{{ user.name }}"
+    password: "{{ user.pass }}"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0664
+  with_items:
+    - changedetection
+
+- name: Create changedetection directories
+  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }} recurse=yes"
+  with_items:
+      - /opt/changedetection/datastore/
+
+- name: Create and start container
+  docker_container:
+    name: changedetection
+    image: "dgtlmoon/changedetection.io"
+    pull: yes
+    published_ports:
+      - "127.0.0.1:5000:5000"
+    env:
+      TZ: "{{ tz }}"
+      UID: "{{ uid }}"
+      GID: "{{ gid }}"
+      VIRTUAL_HOST: "changedetection.{{ user.domain }}"
+      VIRTUAL_PORT: "5000"
+      LETSENCRYPT_HOST: "changedetection.{{ user.domain }}"
+      LETSENCRYPT_EMAIL: "{{ user.email }}"
+    volumes:
+      - "/opt/changedetection/datastore:/datastore"
+    networks:
+      - name: cloudbox
+        aliases:
+          - changedetection
+    pid_mode: host
+    purge_networks: yes
+    restart_policy: unless-stopped
+    state: started

--- a/roles/changedetection/tasks/main.yml
+++ b/roles/changedetection/tasks/main.yml
@@ -42,8 +42,8 @@
     name: changedetection
     image: "dgtlmoon/changedetection.io"
     pull: yes
-    published_ports:
-      - "127.0.0.1:5000:5000"
+    exposed_ports:
+      - 5000
     env:
       TZ: "{{ tz }}"
       UID: "{{ uid }}"
@@ -58,7 +58,6 @@
       - name: cloudbox
         aliases:
           - changedetection
-    pid_mode: host
     purge_networks: yes
     restart_policy: unless-stopped
     state: started


### PR DESCRIPTION
Self-hosted change monitoring of web pages.

# Description

Added Changedetection.io service.
https://github.com/dgtlmoon/changedetection.io

# How Has This Been Tested?

Tested on fresh cb installation, Ubuntu 18.04 server, online and offline multiple times.

# New Role Checklist:

- [x] I have reviewed the [Contribute page in the wiki](https://github.com/Cloudbox/Community/wiki/Contribute)
- [x] I have updated the header in any files I may have used as templates with my own information
- [x] I have added my new role to `appveyor.yml`
- [x] I have added my new role to `community.yml`
- [x] I have verified that any Docker images used are current and supported.
- [x] I have made corresponding changes to the documentation
