### PR TITLE
fix: adding create htpasswd to filebot

### DIFF
--- a/roles/filebot/tasks/main.yml
+++ b/roles/filebot/tasks/main.yml
@@ -16,6 +16,17 @@
     record: filebot
   when: cloudflare_enabled
 
+  - name: Create htpasswd
+  htpasswd:
+    path: "/opt/nginx-proxy/htpasswd/{{ item }}.{{ user.domain }}"
+    name: "{{ user.name }}"
+    password: "{{ user.pass }}"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0664
+  with_items:
+    - filebot
+
 - name: Stop and remove any existing container
   docker_container:
     name: filebot

--- a/roles/filebot/tasks/main.yml
+++ b/roles/filebot/tasks/main.yml
@@ -16,7 +16,7 @@
     record: filebot
   when: cloudflare_enabled
 
-  - name: Create htpasswd
+- name: Create htpasswd
   htpasswd:
     path: "/opt/nginx-proxy/htpasswd/{{ item }}.{{ user.domain }}"
     name: "{{ user.name }}"


### PR DESCRIPTION
# Description

Since filebot can modify the systems files, this should not be exposed as it currently is. This should be password protected as the other applications are. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested on my own personal server using ansible. The user is prompted with a login and the credentials are the cloudbox credentials from accounts.yml.


