### PR TITLE
Adding SmokePing service

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Community Repository for Unofficial Cloudbox Add-ons
 - **radarr1080** - Additional Radarr
 - **radarrX** - Similar to [sonarrX](../../wiki/SonarrX) but for radarr, to create multiple roles
 - **Red Discord Bot** - A customisible self-hosted Discord Bot
+- **[SmokePing](https://hub.docker.com/r/linuxserver/smokeping)** - Smokeping keeps track of your network latency.
 - **sonarr1080** - Additional Sonarr
 - **sonarrv3** - Sonar phantom (v3) branch based role
 - **[sonarrX](../../wiki/SonarrX)** - Experimental Sonarr v3 role to create multiple roles

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -95,6 +95,7 @@ environment:
     requestrrx
     rocketchat
     sickchill
+    smokeping
     sonarrx
     speedtest
     sshwifty

--- a/community.yml
+++ b/community.yml
@@ -96,6 +96,7 @@
     - { role: resilio-sync, tags: ['resilio-sync'] }
     - { role: rocketchat, tags: ['rocketchat'] }
     - { role: sickchill, tags: ['sickchill'] }
+    - { role: smokeping, tags: ['smokeping'] }
     - { role: sonarrx, tags: ['sonarrx'] }
     - { role: speedtest, tags: ['speedtest'] }
     - { role: sshwifty, tags: ['sshwifty'] }

--- a/roles/smokeping/tasks/main.yml
+++ b/roles/smokeping/tasks/main.yml
@@ -1,0 +1,65 @@
+#########################################################################
+# Title:            Community: SmokePing                                #
+# Author(s):        mariosemes                                          #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image(s):  linuxserver/smokeping                               #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: "Set DNS Record on CloudFlare"
+  include_role:
+    name: cloudflare-dns
+  vars:
+    record: smokeping
+  when: cloudflare_enabled
+
+- name: Stop and remove any existing container
+  docker_container:
+    name: smokeping
+    state: absent
+
+- name: Create htpasswd
+  htpasswd:
+    path: "/opt/nginx-proxy/htpasswd/{{ item }}.{{ user.domain }}"
+    name: "{{ user.name }}"
+    password: "{{ user.pass }}"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0664
+  with_items:
+    - smokeping
+
+- name: Create smokeping directories
+  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }} recurse=yes"
+  with_items:
+      - /opt/smokeping/config/
+      - /opt/smokeping/data/
+
+- name: Create and start container
+  docker_container:
+    name: smokeping
+    image: "linuxserver/smokeping"
+    pull: yes
+    exposed_ports:
+      - 80
+    env:
+      TZ: "{{ tz }}"
+      PUID: "{{ uid }}"
+      PGID: "{{ gid }}"
+      VIRTUAL_HOST: "smokeping.{{ user.domain }}"
+      VIRTUAL_PORT: "80"
+      LETSENCRYPT_HOST: "smokeping.{{ user.domain }}"
+      LETSENCRYPT_EMAIL: "{{ user.email }}"
+    volumes:
+      - "/opt/smokeping/config:/config"
+      - "/opt/smokeping/data:/data"
+    networks:
+      - name: cloudbox
+        aliases:
+          - smokeping
+    purge_networks: yes
+    restart_policy: unless-stopped
+    state: started


### PR DESCRIPTION
# Description

Smokeping keeps track of your network latency.
- Basics are, edit the Targets file located in /opt/smokeping/config/Targets to ping the hosts you're interested in to match the format found there.
- Reboot container.

https://hub.docker.com/r/linuxserver/smokeping

# How Has This Been Tested?

- [x] Test A: On already working CB installation, Ubuntu 18.04 server
- [x] Test B: On a clean install of CB. Ubuntu 18.04 server

# New Role Checklist:

- [x] I have reviewed the [Contribute page in the wiki](https://github.com/Cloudbox/Community/wiki/Contribute)
- [x] I have updated the header in any files I may have used as templates with my own information
- [x] I have added my new role to `appveyor.yml`
- [x] I have added my new role to `community.yml`
- [x] I have verified that any Docker images used are current and supported.
- [x] I have made corresponding changes to the documentation
