### PR TITLE
Adding Firefly III service

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,6 +53,7 @@ environment:
     epms
     filebot
     filezilla
+    firefly
     flaresolverr
     funkwhale
     gazee

--- a/community.yml
+++ b/community.yml
@@ -47,6 +47,7 @@
     - { role: filebot, tags: ['filebot'] }
     - { role: filebrowser, tags: ['filebrowser'] }
     - { role: filezilla, tags: ['filezilla'] }
+    - { role: firefly, tags: ['firefly'] }
     - { role: flaresolverr, tags: ['flaresolverr'] }
     - { role: funkwhale, tags: ['funkwhale'] }
     - { role: gazee, tags: ['gazee'] }

--- a/roles/firefly/tasks/main.yml
+++ b/roles/firefly/tasks/main.yml
@@ -41,11 +41,11 @@
     image: "jc5x/firefly-iii:latest"
     pull: yes
     exposed_ports:
-      - "80:8080"
+      - 8080
     env:
       TZ: "{{ tz }}"
-      PGID: "1000"
-      PUID: "1000"
+      PUID: "{{ uid }}"
+      PGID: "{{ gid }}"
       APP_KEY: "{{ lookup('password', '/opt/firefly/passwordfile length=32') }}"
       DB_HOST: "mariadb"
       DB_PORT: "3306"

--- a/roles/firefly/tasks/main.yml
+++ b/roles/firefly/tasks/main.yml
@@ -1,0 +1,70 @@
+#########################################################################
+# Title:            Community: firefly                                  #
+# Author(s):        mariosemes                                          #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image(s):  jc5x/firefly-iii:latest                             #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: "Set DNS Record on CloudFlare"
+  include_role:
+    name: cloudflare-dns
+  vars:
+    record: firefly
+  when: cloudflare_enabled
+
+- name: MariaDB Role
+  include_role:
+    name: mariadb
+
+- name: Stop and remove any existing container
+  docker_container:
+    name: firefly
+    state: absent
+
+- name: Create firefly directories
+  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }} recurse=yes"
+  with_items:
+      - /opt/firefly/upload/
+
+- name: Check if passwordfile exists
+  stat:
+    path: "/opt/firefly/passwordfile"
+  register: passwordfile_exists
+
+- name: Create and start FireFly container
+  docker_container:
+    name: firefly
+    image: "jc5x/firefly-iii:latest"
+    pull: yes
+    exposed_ports:
+      - "80:8080"
+    env:
+      TZ: "{{ tz }}"
+      PGID: "1000"
+      PUID: "1000"
+      APP_KEY: "{{ lookup('password', '/opt/firefly/passwordfile length=32') }}"
+      DB_HOST: "mariadb"
+      DB_PORT: "3306"
+      DB_CONNECTION: "mysql"
+      DB_DATABASE: "firefly"
+      DB_USERNAME: "root"
+      DB_PASSWORD: "password321"
+      VIRTUAL_HOST: "firefly.{{ user.domain }}"
+      VIRTUAL_PORT: "8080"
+      LETSENCRYPT_HOST: "firefly.{{ user.domain }}"
+      LETSENCRYPT_EMAIL: "{{ user.email }}"
+      APP_URL: "https://firefly.{{ user.domain }}"
+      TRUSTED_PROXIES: "**"
+    volumes:
+      - "/opt/firefly/upload:/var/www/html/storage/upload"
+    networks:
+      - name: cloudbox
+        aliases:
+          - firefly
+    purge_networks: yes
+    restart_policy: unless-stopped
+    state: started


### PR DESCRIPTION
Firefly III service added as role.

# Description

Adding Firefly III to the community repo. Firefly III is a free and open source personal finance manager.
More about it here.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Ubuntu 18.04 headless dedicated server with working CB
- [X] Ubuntu 18.04 headless VM with fresh installed CB

# New Role Checklist:

- [X] I have reviewed the [Contribute page in the wiki](https://github.com/Cloudbox/Community/wiki/Contribute)
- [X] I have updated the header in any files I may have used as templates with my own information
- [X] I have added my new role to `appveyor.yml`
- [X] I have added my new role to `community.yml`
- [X] I have verified that any Docker images used are current and supported.
- [X] I have made corresponding changes to the documentation
