### PR TITLE
Easy Countdown (Static countdown page)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,6 +48,7 @@ environment:
     deezloader-remix
     deluge
     delugevpn
+    easycountdown
     embystat
     emby2
     epms

--- a/community.yml
+++ b/community.yml
@@ -41,6 +41,7 @@
     - { role: deluge, tags: ['deluge'] }
     - { role: delugevpn, tags: ['delugevpn'] }
     - { role: drive_strm, tags: ['drive_strm', 'drive_strm_rebuild'] }
+    - { role: easycountdown, tags: [ 'easycountdown'] }
     - { role: embystat, tags: ['embystat'] }
     - { role: emby2, tags: ['emby2'] }
     - { role: epms, tags: ['epms'] }

--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -39,6 +39,11 @@ delugevpn:
   vpn_pass: your_vpn_password
   vpn_prov: pia
   vpn_user: your_vpn_username
+easycountdown:
+  subdomain: easycountdown
+  title: Change me in community settings.yml
+  background: https://raw.githubusercontent.com/jolbol1/CloudboxRoles/main/1920x1080-black-solid-color-background.jpg
+  target: Sat Feb 05 2022 08:15:00 GMT+0000
 gitea: 
   subdomain: git
 goplaxt: 

--- a/roles/easycountdown/tasks/main.yml
+++ b/roles/easycountdown/tasks/main.yml
@@ -1,0 +1,51 @@
+#########################################################################
+# Title:            Community: easycountdown                            #
+# Author(s):        Jolbol1                                             #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image(s):  yooooomi/easy-countdown                             #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: "Setting CloudFlare DNS Record"
+  include_role:
+    name: cloudflare-dns
+  vars:
+    record: "{{ easycountdown.subdomain|default('easycountdown',true) }}"
+  when: cloudflare_enabled
+
+- name: Stop and remove any existing containers
+  docker_container: "name={{ item }} state=absent"
+  with_items:
+    - easycountdown
+
+- name: Create and start countdown container
+  docker_container:
+    name: easycountdown
+    image: "yooooomi/easy-countdown"
+    pull: yes
+    env:
+      TZ: "{{ tz }}"
+      PUID: "{{ uid }}"
+      PGID: "{{ gid }}"
+      VIRTUAL_HOST: "{{ easycountdown.subdomain|default('easycountdown',true) }}.{{ user.domain }}"
+      VIRTUAL_PORT: "3000"
+      LETSENCRYPT_HOST: "{{ easycountdown.subdomain|default('easycountdown',true) }}.{{ user.domain }}"
+      LETSENCRYPT_EMAIL: "{{ user.email }}"
+      TIMER_BACKGROUND: "{{ easycountdown.background|default('https://raw.githubusercontent.com/jolbol1/CloudboxRoles/main/1920x1080-black-solid-color-background.jpg',true) }}"
+      TIMER_TARGET: "{{ easycountdown.target|default('Sat Feb 05 2022 08:15:00 GMT+0000',true) }}"
+      LOG_LEVEL: DEBUG
+      TIMER_TITLE: "{{ easycountdown.title|default('Change me in community settings.yml',true) }}"
+    labels:
+      "com.github.cloudbox.cloudbox_managed": "true"
+    exposed_ports:
+     - 3000
+    networks:
+      - name: cloudbox
+        aliases:
+          - easycountdown
+    purge_networks: yes
+    restart_policy: unless-stopped
+    state: started


### PR DESCRIPTION
# Description

Easy countdown is an easy to setup countdown page. Can be setup as a countdown or as a timer
https://github.com/Yooooomi/easy-countdown

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Ubuntu 18.04 headless server running fresh community branch
- [x] Have been running for months with multiple settings.yml changes and users

# New Role Checklist:

- [x] I have reviewed the [Contribute page in the wiki](https://github.com/Cloudbox/Community/wiki/Contribute)
- [x] I have updated the header in any files I may have used as templates with my own information
- [x] I have added my new role to `appveyor.yml`
- [x] I have added my new role to `community.yml`
- [x] I have verified that any Docker images used are current and supported.
- [x] I have made corresponding changes to the documentation
