### PR TITLE
Moviematch: Change plex url to user variable. Set to local domain by default

### DIFF
--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -64,6 +64,7 @@ lidarrx:
 moviematch:
   subdomain: moviematch
   libraries: Movies
+  plex_url: http://plex:32400
 navidrome: 
   musicfolder: /mnt/unionfs/Media/Music
 ombix: 

--- a/roles/moviematch/tasks/main.yml
+++ b/roles/moviematch/tasks/main.yml
@@ -37,7 +37,7 @@
       PGID: "{{ gid }}"
       VIRTUAL_HOST: "{{ moviematch.subdomain|default('moviematch',true) }}.{{ user.domain }}"
       VIRTUAL_PORT: "8000"
-      PLEX_URL: "https://plex.{{ user.domain }}"
+      PLEX_URL: "{{ moviematch.plex_url }}"
       PLEX_TOKEN: "{{ plex_auth_token | default('') }}"
       LETSENCRYPT_EMAIL: "{{ user.email }}"
       LETSENCRYPT_HOST: "{{ moviematch.subdomain|default('moviematch',true) }}.{{ user.domain }}"


### PR DESCRIPTION
Simple change due to an issue with moviematch in which local domains is the solution. Seems best to make it user variable as well.