### PR TITLE
Update main.yml

### DIFF
--- a/roles/calibre/tasks/main.yml
+++ b/roles/calibre/tasks/main.yml
@@ -1,8 +1,8 @@
-########################################################################
-# Title:            Community: Calibre              #
-# Author(s):        Andrew Johnson and SK                                            #
+#########################################################################
+# Title:            Community: Calibre                                  #
+# Author(s):        Andrew Johnson and SK                               #
 # URL:              https://github.com/Cloudbox/Community               #
-# Docker Image(s):  linuxserver/calibre                         #
+# Docker Image(s):  linuxserver/calibre                                 #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################
@@ -21,6 +21,17 @@
     name: calibre
     state: absent
 
+- name: Create htpasswd
+  htpasswd:
+    path: "/opt/nginx-proxy/htpasswd/{{ item }}.{{ user.domain }}"
+    name: "{{ user.name }}"
+    password: "{{ user.pass }}"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0664
+  with_items:
+    - calibre
+
 - name: Create calibre directories
   file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }}"
   with_items:
@@ -36,8 +47,6 @@
       TZ: "{{ tz }}"
       PUID: "{{ uid }}"
       PGID: "{{ gid }}"
-      GUAC_USER: "{{ user.name }}"
-      GUAC_PASS: "{{ user.pass | hash('md5') }}"
       LIBRARYINTERNALPATH: "/library"
       VIRTUAL_HOST: "calibre.{{ user.domain }}"
       VIRTUAL_PORT: "8080"


### PR DESCRIPTION
GUAC_ envs are deprecated.
Because the new way of handling logins is based on only 1 new env and that is "PASSWORD", which is linked to the user "abc".
In case of CB, we had users made based on CB user.name, and now it doesn't allow you to login.

Removing any password will allow calibre to autologin, and a htpasswd is created as the security step.

Can confirm that it works now without problems after running the role.

# Description

Please include a summary of the change and which issue is fixed if any. Please also include relevant motivation and context. List any dependencies that are required for this change.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Test A
- [x] Test B

# New Role Checklist:

- [ ] I have reviewed the [Contribute page in the wiki](https://github.com/Cloudbox/Community/wiki/Contribute)
- [ ] I have updated the header in any files I may have used as templates with my own information
- [ ] I have added my new role to `appveyor.yml`
- [ ] I have added my new role to `community.yml`
- [ ] I have verified that any Docker images used are current and supported.
- [ ] I have made corresponding changes to the documentation
