### PR TITLE
Changed docker image to vaultwarden

### DIFF
--- a/roles/bitwarden/tasks/main.yml
+++ b/roles/bitwarden/tasks/main.yml
@@ -49,7 +49,7 @@
 - name: Create and start container
   docker_container:
     name: bitwarden
-    image: bitwardenrs/server:latest
+    image: vaultwarden/server:latest
     pull: yes
     published_ports:
       - "127.0.0.1:6423:6423"


### PR DESCRIPTION
# Description

Bitwardenrs project name was changed to vaultwarden, including the docker image.  
See https://github.com/dani-garcia/vaultwarden/discussions/1642 for discussion of the change.

Will update the wiki once the pull request is merged.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Test A
Changed docker image to vaultwarden. Ran role. Confirmed bitwarden functioned as expected.

# Editing Role Checklist:

- [x] I have reviewed the [Contribute page in the wiki](https://github.com/Cloudbox/Community/wiki/Contribute)
- [x] I have verified that any Docker images used are current and supported.