### PR TITLE
Update main.yml for MovieMatch Role

### DIFF
--- a/roles/moviematch/tasks/main.yml
+++ b/roles/moviematch/tasks/main.yml
@@ -42,7 +42,7 @@
       LETSENCRYPT_EMAIL: "{{ user.email }}"
       LETSENCRYPT_HOST: "{{ moviematch.subdomain|default('moviematch',true) }}.{{ user.domain }}"
       LOG_LEVEL: DEBUG
-      LIBRARY_TITLE_FILTER: "{{ moviematch.libraries }}"
+      LIBRARY_FILTER: "{{ moviematch.libraries }}"
     labels:
       "com.github.cloudbox.cloudbox_managed": "true"
     exposed_ports:


### PR DESCRIPTION
# Description

Was having an issue, documented here: https://github.com/Cloudbox/Community/issues/369

The Role was using "LIBRARY_TITLE_FILTER", which is a v2 variable. - https://github.com/LukeChannings/moviematch/blob/main/README.markdown#Configuration
Should have been using "LIBRARY_FILTER" variable as the latest stable is v.1.10 which has different variables. - https://github.com/LukeChannings/moviematch/tree/v1#configuration

# How Has This Been Tested?

Modified the role's `main.yml` file with the aforementioned edit and ran the role, this time it loaded all the specified libraries from the `community/settings.yml` file.

New debug output shows:

```
DEBUG Log level DEBUG

DEBUG getSections: http://plex:32400/library/sections

INFO Listening on port 8000

DEBUG Available libraries: Kids Movies, Movies, Stand-up Comedy, Anime, Kids TV Shows, Spanish TV Shows, TV Shows, Music

DEBUG selected library titles - Movies, Kids Movies, Stand-up Comedy

DEBUG Loading movies from Kids Movies library

DEBUG Loaded http://plex:32400/library/sections/3/all?X-Plex-Token=XXXXXXXXXXXXXXXXXX: 200 OK

DEBUG Loaded 272 items from Kids Movies

DEBUG Loading movies from Movies library

DEBUG Loaded http://plex:32400/library/sections/1/all?X-Plex-Token=XXXXXXXXXXXXXXXXXX: 200 OK

DEBUG Loaded 1214 items from Movies

DEBUG Loading movies from Stand-up Comedy library

DEBUG Loaded http://plex:32400/library/sections/11/all?X-Plex-Token=XXXXXXXXXXXXXXXXXX: 200 OK

DEBUG Loaded 74 items from Stand-up Comedy
```