### PR TITLE
sonarrx: change image to release

### DIFF
--- a/roles/sonarrx/tasks/template.yml
+++ b/roles/sonarrx/tasks/template.yml
@@ -47,7 +47,7 @@
 - name: Create and start container
   docker_container:
     name: "sonarr{{ rolename }}"
-    image: "hotio/sonarr:nightly"
+    image: "hotio/sonarr:release"
     pull: yes
     env:
       TZ: "{{ tz }}"


### PR DESCRIPTION
Since sonarr v3 is now stable i propose changing the image to release.
Was already done in Cloudbox/Cloudbox see https://github.com/Cloudbox/Cloudbox/commit/d2416b8f032fbee59b2457b796b1c2d2b41f818f

# How Has This Been Tested?

This is a simple change, I tested it on my Cloudbox installation
