### PR TITLE
Update main.yml

### DIFF
--- a/roles/deemix/tasks/main.yml
+++ b/roles/deemix/tasks/main.yml
@@ -42,6 +42,7 @@
       UMASK_SET: "022"
       PUID: "{{ uid }}"
       PGID: "{{ gid }}"
+      REVERSEPROXY: true
     volumes:
       - "/mnt:/mnt"
       - "/opt/deemix:/config"


### PR DESCRIPTION
# Description

deemix currently won't load behind a reverse proxy without setting the env variable for a reverse proxy. 
The note about it can be seen here: https://gitlab.com/Bockiii/deemix-docker

# How Has This Been Tested?

Ran on an ubuntu 18.04 install of Cloudbox, both a fresh install and the one I use daily.
