### PR TITLE
Adding Readarr role via hotio/readarr container, and light cleanup of README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
           - qbittorrentvpn
           - quassel
           - radarrx
+          - readarr
           - redbot
           - redis
           - resilio-sync

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This is a partial list of roles available via Community; once the repo is instal
 - **[goplaxt](../../wiki/Goplaxt)** - [goplaxt](https://github.com/XanderStrike/goplaxt) Plex/Trakt Scrobbler
 - **Handbrake** - GUI application (no installation or configuration needed on client-side)
 - **invoiceninja**
+- **[jdownloader2](../../wiki/JDownloader2)** - [JDownloader2](https://github.com/jlesage/docker-jdownloader-2) Self-hosted free, open-source download management tool with GUI website frontend.
 - **jellyfin** - [jellyfin](https://github.com/jellyfin/jellyfin) emby fork
 - **kitana** - A responsive Plex plugin web frontend
 - **[komga](https://komga.org/)** - comics server and online reader (similar to ubooquity, but actively developed as of today); to get the original admin username and passowrd, type docker logs komga and follow the [help](https://komga.org/installation/user-accounts.html#automatic-mode-default)
@@ -52,8 +53,8 @@ This is a partial list of roles available via Community; once the repo is instal
 - **[mediabutler](../../wiki/Mediabutler)** - Discord bot
 - **[medusa](https://pymedusa.com)** - TV Shows manager
 - **[mellow](../../wiki/Mellow-Discord-Bot)** - Discord Bot
+- **[mkvtoolnix](https://github.com/jlesage/docker-mkvtoolnix)** - MKVToolNix GUI - a set of tools to create, alter and inspect Matroska files
 - **monitorr**
-- **[jdownloader2](../../wiki/JDownloader2)** - [JDownloader2](https://github.com/jlesage/docker-jdownloader-2) Self-hosted free, open-source download management tool with GUI website frontend.
 - **mylar** - automated comic book downloader
 - **mylar3** - newest version of the automated comic book downloader, migrated to python 3. Actively developed.
 - **Overseerr** - Plex request management and media discovery tool
@@ -61,6 +62,7 @@ This is a partial list of roles available via Community; once the repo is instal
 - **[qBittorrent](../../wiki/qBittorrent)** - qBittorrent torrent client
 - **radarr1080** - Additional Radarr
 - **radarrX** - Similar to [sonarrX](../../wiki/SonarrX) but for radarr, to create multiple roles
+- **[readarr](https://hotio.dev/containers/readarr/)** - BETA role of Readarr for eBook or Audiobook use, supports integration with 'Calibre' role
 - **Red Discord Bot** - A customisible self-hosted Discord Bot
 - **[SmokePing](https://hub.docker.com/r/linuxserver/smokeping)** - Smokeping keeps track of your network latency.
 - **sonarr1080** - Additional Sonarr

--- a/community.yml
+++ b/community.yml
@@ -105,6 +105,7 @@
     - { role: qbittorrentvpn, tags: ['qbittorrentvpn'] }
     - { role: quassel, tags: ['quassel'] }
     - { role: radarrx, tags: ['radarrx'] }
+    - { role: readarr, tags: ['readarr'] }
     - { role: redbot, tags: ['redbot'] }
     - { role: redis, tags: ['redis'] }
     - { role: requestrr, tags: ['requestrr'] }

--- a/roles/readarr/tasks/main.yml
+++ b/roles/readarr/tasks/main.yml
@@ -2,20 +2,12 @@
 # Title:            Community: Readarr                                  #
 # Author(s):        edzeg                                               #
 # URL:              https://github.com/Cloudbox/Community               #
-# Docker Image(s):  hotio/readarr:nightly                               #
+# Docker Image(s):  hotio/readarr                                       #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################
 #                   GNU General Public License v3.0                     #
 #########################################################################
-#                                                        #
-# *****NOTES*****                                        #
-# 1) Currently only Nightly tag is available.            #
-#    Once stable is available will change to Latest      #
-#                                                        #
-# 2) The 'Media/Books' directory is passed as '/library' #
-#    in order to allow integration with 'Calibre' role   #
-##########################################################
 ---
 - name: "Setting CloudFlare DNS Record"
   include_role:
@@ -47,8 +39,6 @@
     name: readarr
     image: hotio/readarr:nightly
     pull: yes
-    published_ports:
-      - "127.0.0.1:8787:8787"
     env:
       BACKUP: "no"
       PUID: "{{ uid }}"

--- a/roles/readarr/tasks/main.yml
+++ b/roles/readarr/tasks/main.yml
@@ -1,0 +1,71 @@
+#########################################################################
+# Title:            Community: Readarr                                  #
+# Author(s):        edzeg                                               #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image(s):  hotio/readarr:nightly                               #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+#                                                        #
+# *****NOTES*****                                        #
+# 1) Currently only Nightly tag is available.            #
+#    Once stable is available will change to Latest      #
+#                                                        #
+# 2) The 'Media/Books' directory is passed as '/library' #
+#    in order to allow integration with 'Calibre' role   #
+##########################################################
+---
+- name: "Setting CloudFlare DNS Record"
+  include_role:
+    name: cloudflare-dns
+  vars:
+    record: readarr
+  when: cloudflare_enabled
+
+- name: Stop and remove any existing container
+  docker_container:
+    name: readarr
+    state: absent
+
+- name: Create readarr directories
+  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }}"
+  with_items:
+    - /opt/readarr
+
+- name: Set default_volumes variable
+  set_fact:
+    default_volumes:
+      - "/opt/readarr:/config"
+      - "/opt/scripts:/scripts"
+      - "/mnt:/mnt"
+      - "/mnt/unionfs/Media/Books:/library"
+
+- name: Create and start container
+  docker_container:
+    name: readarr
+    image: hotio/readarr:nightly
+    pull: yes
+    published_ports:
+      - "127.0.0.1:8787:8787"
+    env:
+      BACKUP: "no"
+      PUID: "{{ uid }}"
+      PGID: "{{ gid }}"
+      UMASK: 002
+      VIRTUAL_HOST: "readarr.{{ user.domain }}"
+      VIRTUAL_PORT: 8787
+      LETSENCRYPT_HOST: "readarr.{{ user.domain }}"
+      LETSENCRYPT_EMAIL: "{{ user.email }}"
+      TZ: "{{ tz }}"
+    volumes: "{{ default_volumes + nzbs_downloads_path|default([]) + torrents_downloads_path|default([]) }}"
+    labels:
+      "com.github.cloudbox.cloudbox_managed": "true"
+    networks:
+      - name: cloudbox
+        aliases:
+          - readarr
+    purge_networks: yes
+    restart_policy: unless-stopped
+    state: started


### PR DESCRIPTION
# Description

Added Readarr role using 'hotio/readarr' container.
Currently there is only 'nightly' images, no 'latest' as in BETA, however functionality is good.
Once a 'latest' tag is available will edit role.

Also, "Media/Books" is passed along as "/library" in order to work well with the 'Calibre' role when using it's server function, allowing Calibre to manage media provided by Readarr.


# How Has This Been Tested?

Used to build eBook library alongside Jackett/NZBHydra2 with DelugeVPN/NZBget.
Content passed to 'Calibre', and can also be browsed and downloaded via 'Calibre-web' to eReaders.


# New Role Checklist:

- [✓] I have reviewed the [Contribute page in the wiki](https://github.com/Cloudbox/Community/wiki/Contribute)
- [✓] I have updated the header in any files I may have used as templates with my own information
- [✓] I have added my new role to `[COMMUNITY REPO ROOT]/.github/workflows/ci.yml`
- [✓] I have added my new role to `community.yml`
- [~✓] I have verified that any Docker images used are current and supported.
- [✓] I have made corresponding changes to the documentation