### PR TITLE
Added Scrutiny role for monitoring S.M.A.R.T. data of drives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
           - resilio-sync
           - requestrrx
           - rocketchat
+          - scrutiny
           - searx
           - sickchill
           - smokeping

--- a/README.md
+++ b/README.md
@@ -18,25 +18,25 @@ Community Repository for Unofficial Cloudbox Add-ons
 
 This is a partial list of roles available via Community; once the repo is installed,`sudo ansible-playbook community.yml --list-tags` will show you all available roles.
 
-- **[arrX](../../wiki/arrX)** - Create multiple Sonarr/Radarr/Bazarr Docker containers.
 - **airsonic**
 - **[alltube](../../wiki/alltube)** - [alltube](https://github.com/Rudloff/alltube) HTML GUI for youtube-dl.
 - **[alternatrr](../../wiki/alternatrr)** - [alternatrr](https://github.com/TheUltimateC0der/alternatrr) alternatrr lets you add alternative titles to your sonarr instance with a simple WebUI.
 - **amongus** - [AmongUsAutoMute](https://github.com/denverquane/amongusdiscord) AmongUs discord auto mute bot.
+- **[arrX](../../wiki/arrX)** - Create multiple Sonarr/Radarr/Bazarr Docker containers.
 - **[beets](../../wiki/beets)** - [Beets](http://beets.io/) Music library manager and MusicBrainz tagger.
 - **[bitwarden](../../wiki/Bitwarden)** - [Bitwarden](https://bitwarden.com/) Installs a self-hosted Bitwarden CE instance.
 - **[bookstack](../../wiki/Bookstack)** - [BookStack](https://www.bookstackapp.com/) Self-hosted platform for organising and storing information.
 - **[calibre-rdp](../../wiki/Calibre-RDP-and-Calibre-WEB)** - [Calibre-RDP](https://github.com/cgspeck/docker-rdp-calibre) Media path set to `/Media/Books` - a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.
 - **[calibre-web](../../wiki/Calibre-RDP-and-Calibre-WEB)** - [Calibre-RDP](https://github.com/janeczku/calibre-web) Loads opt/calibre - a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.
 - **[changedetection.io](https://github.com/dgtlmoon/changedetection.io)** - Self-hosted change monitoring of web pages.
-- **[comixed](https://github.com/mcpierce/comixed/tree/develop/docker)** - comics server and online reader
 - **[comicstreamer](https://github.com/beville/ComicStreamer)** - comics server and online reader (old, unmaintained, but fast and efficient)
+- **[comixed](https://github.com/mcpierce/comixed/tree/develop/docker)** - comics server and online reader
 - **[conreq](https://github.com/Archmonger/Conreq)** - Conreq, a Content Requesting platform like ombi
 - **[CouchPotato](https://couchpota.to)** - Movie manager
 - **[Deemixrr](https://github.com/TheUltimateC0der/Deemixrr/wiki)** - A smart and easy to use WebUI for deemix to manage your music and audiobooks
 - **[deluge](../../wiki/Deluge)** - Deluge torrent client
-- **[embystat](https://github.com/mregni/EmbyStat)**
 - **Emby2** - Second instance of Emby
+- **[embystat](https://github.com/mregni/EmbyStat)**
 - **flaresolverr** - Captcha resolver to be used jointly with [Jackett to solve cloudflare challenges](https://github.com/Jackett/Jackett/issues/9029)
 - **funkwhale**
 - **gazee** - comic book reader
@@ -64,6 +64,7 @@ This is a partial list of roles available via Community; once the repo is instal
 - **radarrX** - Similar to [sonarrX](../../wiki/SonarrX) but for radarr, to create multiple roles
 - **[readarr](https://hotio.dev/containers/readarr/)** - BETA role of Readarr for eBook or Audiobook use, supports integration with 'Calibre' role
 - **Red Discord Bot** - A customisible self-hosted Discord Bot
+- **[scrutiny](https://hotio.dev/containers/scrutiny/)** - View/Monito S.M.A.R.T data for your server's drives with **[scrutiny](https://github.com/analogj/scrutiny)** using hotio's image. You will need to add/edit/remove "DEVICES" under 'Scrutiny' in the 'settings.yml' file in the community directory.
 - **[SmokePing](https://hub.docker.com/r/linuxserver/smokeping)** - Smokeping keeps track of your network latency.
 - **sonarr1080** - Additional Sonarr
 - **sonarrv3** - Sonar phantom (v3) branch based role

--- a/community.yml
+++ b/community.yml
@@ -113,6 +113,7 @@
     - { role: requestrrx, tags: ['requestrrx'] }
     - { role: resilio-sync, tags: ['resilio-sync'] }
     - { role: rocketchat, tags: ['rocketchat'] }
+    - { role: scrutiny, tags: ['scrutiny'] }
     - { role: searx, tags: ['searx'] }
     - { role: sickchill, tags: ['sickchill'] }
     - { role: smokeping, tags: ['smokeping'] }

--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -106,6 +106,10 @@ requestrrx:
   roles: 
     - 1080
     - 4k
+scrutiny:
+  devices:
+    - /dev/sda
+    - /dev/sdb
 searx:
   subdomain: searx
 sonarrx: 

--- a/roles/scrutiny/tasks/main.yml
+++ b/roles/scrutiny/tasks/main.yml
@@ -1,0 +1,76 @@
+#########################################################################
+# Title:            Community: scrutiny                                  #
+# Author(s):        edzeg                                               #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image(s):  hotio/scrutiny                                      #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: "Setting CloudFlare DNS Record"
+  include_role:
+    name: cloudflare-dns
+  vars:
+    record: scrutiny
+  when: cloudflare_enabled
+
+- name: Stop and remove any existing container
+  docker_container:
+    name: scrutiny
+    state: absent
+
+- name: Lookup htpasswd
+  stat:
+    path: "/opt/nginx-proxy/htpasswd/scrutiny.{{ user.domain }}"
+  register: htpasswd_lookup
+
+- name: Create htpasswd
+  htpasswd:
+    path: "/opt/nginx-proxy/htpasswd/scrutiny.{{ user.domain }}"
+    name: "{{ user.name }}"
+    password: "{{ user.pass }}"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0664
+  when: not htpasswd_lookup.stat.exists
+  
+- name: Create scrutiny directories
+  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }}"
+  with_items:
+    - /opt/scrutiny
+
+- name: Set default_volumes variable
+  set_fact:
+    default_volumes:
+      - "/opt/scrutiny:/config"
+      - "/run/udev:/run/udev:ro"
+
+- name: Create and start container
+  docker_container:
+    name: scrutiny
+    image: hotio/scrutiny
+    pull: yes
+    env:
+      BACKUP: "no"
+      PUID: "{{ uid }}"
+      PGID: "{{ gid }}"
+      UMASK: "002"
+      VIRTUAL_HOST: "scrutiny.{{ user.domain }}"
+      VIRTUAL_PORT: "8080"
+      LETSENCRYPT_HOST: "scrutiny.{{ user.domain }}"
+      LETSENCRYPT_EMAIL: "{{ user.email }}"
+      TZ: "{{ tz }}"
+    volumes: "{{ default_volumes }}"
+    capabilities:
+      - SYS_RAWIO
+    devices: "{{ scrutiny.devices }}"
+    labels:
+      "com.github.cloudbox.cloudbox_managed": "true"
+    networks:
+      - name: cloudbox
+        aliases:
+          - scrutiny
+    purge_networks: yes
+    restart_policy: unless-stopped

--- a/roles/scrutiny/tasks/main.yml
+++ b/roles/scrutiny/tasks/main.yml
@@ -1,5 +1,5 @@
 #########################################################################
-# Title:            Community: scrutiny                                  #
+# Title:            Community: scrutiny                                 #
 # Author(s):        edzeg                                               #
 # URL:              https://github.com/Cloudbox/Community               #
 # Docker Image(s):  hotio/scrutiny                                      #
@@ -62,9 +62,13 @@
       LETSENCRYPT_HOST: "scrutiny.{{ user.domain }}"
       LETSENCRYPT_EMAIL: "{{ user.email }}"
       TZ: "{{ tz }}"
+      INTERVAL: "86400"
+      API_ENDPOINT: "http://localhost:8080"
+      MODE: "both"
     volumes: "{{ default_volumes }}"
     capabilities:
       - SYS_RAWIO
+      - SYS_ADMIN
     devices: "{{ scrutiny.devices }}"
     labels:
       "com.github.cloudbox.cloudbox_managed": "true"

--- a/roles/scrutiny/tasks/main.yml
+++ b/roles/scrutiny/tasks/main.yml
@@ -53,7 +53,6 @@
     image: hotio/scrutiny
     pull: yes
     env:
-      BACKUP: "no"
       PUID: "{{ uid }}"
       PGID: "{{ gid }}"
       UMASK: "002"


### PR DESCRIPTION
# Description

Scrutiny allows the viewing/monitoring of the S.M.A.R.T. data from your server's drives.

Before running role user will need to add/edit/remove the drives under 'Scrutiny: Devices:' sub-section in the community 'settings.yml'.
Default assumes you have two drives, listed as such:
- /dev/sda
- /dev/sdb

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [✓] Created and verified role on server.
- [✓ ] Tested role with different single and dual devices

# New Role Checklist:

- [✓] I have reviewed the [Contribute page in the wiki](https://github.com/Cloudbox/Community/wiki/Contribute)
- [✓] I have updated the header in any files I may have used as templates with my own information
- [✓] I have added my new role to `[COMMUNITY REPO ROOT]/.github/workflows/ci.yml`
- [✓] I have added my new role to `community.yml`
- [✓] I have verified that any Docker images used are current and supported.
- [✓] I have made corresponding changes to the documentation

(Edit to Wiki will follow)
