### PR TITLE
removed the "config" bind

### DIFF
--- a/roles/minecraft/tasks/main.yml
+++ b/roles/minecraft/tasks/main.yml
@@ -46,7 +46,6 @@
       LETSENCRYPT_EMAIL: "{{ user.email }}"
     volumes:
       - "/etc/localtime:/etc/localtime:ro"
-      - "/opt/minecraft:/config"
       - "/opt/minecraft/data:/data"
     labels:
       "com.github.cloudbox.cloudbox_managed": "true"


### PR DESCRIPTION
# Description

The config bind makes the community role not work properly. Removing it fixes it. This is because of a change in the docker image and the role just hasnt been adjusted yet. 

# How Has This Been Tested?

I deleted the bind, created a Server and did basic functionality testing. Everything seemed to work properly
