### PR TITLE
Update host for LazyMan ip lookup

### DIFF
--- a/roles/jellyfin/tasks/main.yml
+++ b/roles/jellyfin/tasks/main.yml
@@ -68,7 +68,7 @@
   register: dev_dri
 
 - name: "Get IP for LazyMan"
-  set_fact: lazyman_ip="{{ lookup('dig', 'nhl.freegamez.ga.', '@8.8.8.8', 'qtype=A') }}"
+  set_fact: lazyman_ip="{{ lookup('dig', 'freesports.ddns.net.', '@8.8.8.8', 'qtype=A') }}"
 
 - name: "Set custom hosts"
   set_fact:


### PR DESCRIPTION
# Description

Updated host for LazyMan ip lookup. Previous host is no longer valid.

# How Has This Been Tested?

Tested by running role on my cloud box installation.

- [x] Test name resolution of new host
- [x] Test role successfully runs with new host