### PR TITLE
Add a "data" directory since transmissionvpn expects it

### DIFF
--- a/roles/transmissionvpn/tasks/main.yml
+++ b/roles/transmissionvpn/tasks/main.yml
@@ -40,9 +40,7 @@
 # https://haugene.github.io/docker-transmission-openvpn/run-container/#1_the_container_assumes_that_you_mount_a_folder_to_data
 - name: Set the data_volume variable
   set_fact:
-    data_volume:
-      - "{{ downloads.torrents }}/transmissionvpn:/data"
-  when: (torrents_downloads_path is defined)|default(false)
+    data_volume: "{{[downloads.torrents + '/transmissionvpn:/data'] if torrents_downloads_path_is_defined else [] }}"
 
 - name: Set default_volumes variable
   set_fact:

--- a/roles/transmissionvpn/tasks/main.yml
+++ b/roles/transmissionvpn/tasks/main.yml
@@ -37,6 +37,13 @@
     - "{{ downloads.torrents }}/transmissionvpn/torrents"
   when: (torrents_downloads_path is defined)|default(false)
 
+# https://haugene.github.io/docker-transmission-openvpn/run-container/#1_the_container_assumes_that_you_mount_a_folder_to_data
+- name: Set the data_volume variable
+  set_fact:
+    data_volume:
+      - "{{ downloads.torrents }}/transmissionvpn:/data"
+  when: (torrents_downloads_path is defined)|default(false)
+
 - name: Set default_volumes variable
   set_fact:
     default_volumes:
@@ -67,7 +74,7 @@
       TRANSMISSION_WATCH_DIR_ENABLED: "false"
       TRANSMISSION_HOME: "/opt/transmissionvpn"
       TZ: "{{ tz }}"
-    volumes: "{{ default_volumes + torrents_downloads_path|default([]) }}"
+    volumes: "{{ default_volumes + torrents_downloads_path + data_volume|default([]) }}"
     dns_servers: 8.8.8.8
     labels:
       "com.github.cloudbox.cloudbox_managed": "true"


### PR DESCRIPTION
# Description

The transmissionvpn docker image assumes that you have mounted a volume to /data, and sets a lot of defaults based on that, such as the default download dir, incomplete downloads dir, and watch dir. 
![Screen Shot 2022-02-21 at 5 14 27 PM](https://user-images.githubusercontent.com/8764853/155045531-2991182d-9f3a-4233-96de-8b7375f424a6.png)
When I installed transmissionvpn this data volume was not configured. This meant that docker generated the volume automatically and transmission used that dir rather than downloading to the created torrents folders.

I added a mount point pointing `data` (in the container) to `{{ downloads.torrents }}/transmissionvpn` (on the disk).

# How Has This Been Tested?

Ran it locally and verified in portainer that it was being mounted correctly:  
![Screen Shot 2022-02-21 at 5 12 57 PM](https://user-images.githubusercontent.com/8764853/155045397-ba242ab7-dee0-4b73-a5d4-56853bf8a388.png)

I wasn't sure how to test it in the case that `torrents_download_path` doesn't exist and would appreciate any input you have on whether my code looks correct