### PR TITLE
add Whisparr

### DIFF
--- a/community.yml
+++ b/community.yml
@@ -136,6 +136,7 @@
     - { role: vscode, tags: ['vscode'] }
     - { role: watchtower, tags: ['watchtower'] }
     - { role: wallabag, tags: ['wallabag'] }
+    - { role: whisparr, tags: ['whisparr'] }
     - { role: wordpress, tags: ['wordpress'] }
     - { role: xbackbone, tags: ['xbackbone'] }
     - { role: xteve, tags: ['xteve'] }

--- a/roles/whisparr/tasks/main.yml
+++ b/roles/whisparr/tasks/main.yml
@@ -1,0 +1,61 @@
+#########################################################################
+# Title:         Community: Whisparr                                    #
+# Author(s):     L0rdShrek                                              #
+# URL:           https://github.com/Cloudbox/Community                  #
+# Docker Image(s):  cr.hotio.dev/hotio/whisparr                         #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: "Set DNS Record on CloudFlare"
+  include_role:
+    name: cloudflare-dns
+  vars:
+    record: whisparr
+  when: cloudflare_enabled
+
+- name: Stop and remove any existing container
+  docker_container:
+    name: whisparr
+    state: absent
+
+- name: Create whisparr directories
+  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }}"
+  with_items:
+    - /opt/whisparr
+
+- name: Set default_volumes variable
+  set_fact:
+    default_volumes:
+      - "/opt/whisparr:/config"
+      - "/opt/scripts:/scripts"
+      - "/mnt:/mnt"
+      - "/mnt/unionfs/Media/adult:/adult"
+
+- name: Create and start container
+  docker_container:
+    name: whisparr
+    image: cr.hotio.dev/hotio/whisparr:nightly
+    pull: yes
+    env:
+      TZ: "{{ tz }}"
+      PUID: "{{ uid }}"
+      PGID: "{{ gid }}"
+      UMASK: "002"
+      VIRTUAL_HOST: "whisparr.{{ user.domain }}"
+      VIRTUAL_PORT: "6969"
+      LETSENCRYPT_HOST: "whisparr.{{ user.domain }}"
+      LETSENCRYPT_EMAIL: "{{ user.email }}"
+    volumes: "{{ default_volumes + nzbs_downloads_path|default([]) + torrents_downloads_path|default([]) }}"
+    labels:
+      "com.github.cloudbox.cloudbox_managed": "true"
+      "com.github.cloudbox.community": "whisparr"
+    networks:
+      - name: cloudbox
+        aliases:
+          - whisparr
+    purge_networks: yes
+    restart_policy: unless-stopped
+    state: started


### PR DESCRIPTION
# Description
Whisparr is an adult movie collection manager for Usenet and BitTorrent users.

# How Has This Been Tested?
- [x] Installed on a Ubuntu 18.04 server running Cloudbox
- [x] Run the new Role multiple Times 

# New Role Checklist:
- [x] I have reviewed the [Contribute page in the wiki](https://github.com/Cloudbox/Community/wiki/Contribute)
- [x] I have updated the header in any files I may have used as templates with my own information
- [x] I have added my new role to `community.yml`
- [x] I have verified that any Docker images used are current and supported.
