### PR TITLE
fix(overseerr): force container to use Google DNS to fix TMDB API issues.

### DIFF
--- a/roles/overseerr/tasks/main.yml
+++ b/roles/overseerr/tasks/main.yml
@@ -58,6 +58,8 @@
       - name: cloudbox
         aliases:
           - overseerr
+    dns_servers:
+      - 8.8.8.8
     purge_networks: yes
     restart_policy: unless-stopped
     state: started

--- a/roles/overseerrx/tasks/template.yml
+++ b/roles/overseerrx/tasks/template.yml
@@ -52,6 +52,8 @@
       - name: cloudbox
         aliases:
           - "overseerr{{ rolename }}"
+    dns_servers:
+      - 8.8.8.8
     purge_networks: yes
     restart_policy: unless-stopped
     state: started


### PR DESCRIPTION
# Description

For some reason, with many DNS providers, TMDB resolves to 127.0.0.1, which completely breaks Overseerr. Using Cloudflare DNS, this happens as well. The Google DNS servers still seem to resolve it fine though. This patch forces the Overseerr container to use Google DNS and thereby fixing this issue for many users, including myself.

# How Has This Been Tested?

- [X] Re-ran the Overseerr role to see if it still correctly builds the container
- [X] Verified that the newly created Overseerr container no longer has issues connecting to the TMDB.

# Notes

I understand that this might not get merged as this is somewhat of a hotfix/workaround which is not required for everybody running this. From what I hear, it mostly affects users running this on Hetzner servers. However, this seems like a cleaner way to fix this issue than having to change the DNS servers for my entire server.

