### PR TITLE
Add tdarrv2 role

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This is a partial list of roles available via Community; once the repo is instal
 - **[speedtest](https://github.com/adolfintel/speedtest)** - Self-hosted HTML5 Speedtest
 - **subsonic**
 - **[telly](../../wiki/Telly)**
+- **[tdarrv2](../../wiki/tdarrv2)** - Tdarr V2 is a cross-platform conditional based transcoding application for automating media library transcode/remux management in order to process your media files as required.
 - **[transmissionvpn](https://github.com/haugene/docker-transmission-openvpn)**
 - **[transmissionx](../../wiki/transmissionx)** - lightweight torrent client - role to create multiple roles (default is one)
 - **ubooquity** - comics server and online reader (ubooquity.your.server/ubooquity for main page / your.ip:2203/ubooquity/admin for admin)

--- a/community.yml
+++ b/community.yml
@@ -124,7 +124,7 @@
     - { role: synclounge, tags: ['synclounge'] }
     - { role: tdarr, tags: ['tdarr'] }
     - { role: tdarrv2, tags: ['tdarrv2'] }
-    - { role: tdarrv2-node, tags: ['tdarrv2'] }
+    - { role: tdarrv2-node, tags: ['tdarrv2', 'tdarrv2-node'] }
     - { role: telegraf, tags: ['telegraf'] }
     - { role: telly, tags: ['telly'] }
     - { role: thelounge, tags: ['thelounge'] }

--- a/community.yml
+++ b/community.yml
@@ -123,6 +123,8 @@
     - { role: subsonic, tags: ['subsonic'] }
     - { role: synclounge, tags: ['synclounge'] }
     - { role: tdarr, tags: ['tdarr'] }
+    - { role: tdarrv2, tags: ['tdarrv2'] }
+    - { role: tdarrv2-node, tags: ['tdarrv2'] }
     - { role: telegraf, tags: ['telegraf'] }
     - { role: telly, tags: ['telly'] }
     - { role: thelounge, tags: ['thelounge'] }

--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -131,6 +131,8 @@ transmissionx:
     - ""
 unifi: 
   port: 8080
+varken:
+  tautulli_subdomain: plexpy
 wordpress: 
   direct_domain: false
   subdomain: wordpress

--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -121,6 +121,7 @@ tdarrv2:
   subdomain: tdarrv2
   direct_domain: false
   transcode_dir: /tdarrv2_transcode_tmp_cache
+  serverip: tdarrv2
 transmissionvpn: 
   vpn_endpoint: netherlands.ovpn
   vpn_pass: your_vpn_password

--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -117,6 +117,10 @@ sonarrx:
 synclounge: 
   domain: ~
   subdomain: synclounge
+tdarrv2:
+  subdomain: tdarrv2
+  direct_domain: false
+  transcode_dir: /tdarrv2_transcode_tmp_cache
 transmissionvpn: 
   vpn_endpoint: netherlands.ovpn
   vpn_pass: your_vpn_password
@@ -127,8 +131,6 @@ transmissionx:
     - ""
 unifi: 
   port: 8080
-varken: 
-  tautulli_subdomain: plexpy
 wordpress: 
   direct_domain: false
   subdomain: wordpress

--- a/roles/tdarrv2-node/tasks/main.yml
+++ b/roles/tdarrv2-node/tasks/main.yml
@@ -1,0 +1,62 @@
+#########################################################################
+# Title:            Community: Tdarrv2                                  #
+# Author(s):        Kungfoome | Visorak, Migz                           #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image(s):  haveagitgat/tdarr                                   #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+   
+- name: "Check if '/dev/dri' exists"
+  stat:
+    path: "/dev/dri"
+  register: dev_dri
+
+- name: Stop and remove any existing container
+  docker_container:
+    name: tdarrv2-node
+    state: absent
+
+- name: Create tdarr directories
+  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }}"
+  with_items:
+    - /opt/tdarrv2
+    - /opt/tdarrv2/config
+    - /opt/tdarrv2/logs
+    - "{{ (tdarrv2.transcode_dir|default('/tdarrv2_transcode_tmp_cache',true)) }}"
+
+- name: Create and start container
+  docker_container:
+    name: tdarrv2-node
+    image: ghcr.io/haveagitgat/tdarr_node 
+    pull: yes
+    env:
+      TZ: "{{ tz }}"
+      PUID: "{{ uid }}"
+      PGID: "{{ gid }}"
+      NVIDIA_DRIVER_CAPABILITIES: "{{ 'all' if gpu.nvidia | default(false) else omit }}"
+      NVIDIA_VISIBLE_DEVICES: "{{ 'all' if gpu.nvidia | default(false) else omit }}"
+      nodeID: MainNode
+      nodeIP: tdarrv2-node
+      serverIP: tdarrv2
+    volumes:
+      - "/mnt/unionfs/Media:/media"
+      - "/mnt:/mnt"
+      - "/opt/tdarrv2/config:/app/configs"
+      - "/opt/tdarrv2/logs:/app/logs"
+      - "/dev/shm:/dev/shm"
+      - "{{ (tdarrv2.transcode_dir|default('/tdarrv2_transcode_tmp_cache',true)) }}:/transcode_tmp_cache"
+    devices: "{{ '/dev/dri:/dev/dri' if (gpu.intel and dev_dri.stat.exists) | default(false) else omit }}"
+    labels:
+      "com.github.cloudbox.cloudbox_managed": "true"
+    networks:
+      - name: cloudbox
+        aliases:
+          - tdarrv2-node
+    purge_networks: yes
+    restart_policy: unless-stopped
+    state: started
+

--- a/roles/tdarrv2-node/tasks/main.yml
+++ b/roles/tdarrv2-node/tasks/main.yml
@@ -39,9 +39,9 @@
       PGID: "{{ gid }}"
       NVIDIA_DRIVER_CAPABILITIES: "{{ 'all' if gpu.nvidia | default(false) else omit }}"
       NVIDIA_VISIBLE_DEVICES: "{{ 'all' if gpu.nvidia | default(false) else omit }}"
-      nodeID: MainNode
-      nodeIP: tdarrv2-node
-      serverIP: tdarrv2
+      nodeID: "MainNode"
+      nodeIP: "tdarrv2-node"
+      serverIP: "{{ tdarrv2.serverip }}"
     volumes:
       - "/mnt/unionfs/Media:/media"
       - "/mnt:/mnt"

--- a/roles/tdarrv2/tasks/main.yml
+++ b/roles/tdarrv2/tasks/main.yml
@@ -1,0 +1,82 @@
+#########################################################################
+# Title:            Community: Tdarrv2                                  #
+# Author(s):        Kungfoome | Visorak, Migz                           #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image(s):  haveagitgat/tdarr                                   #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: "Setting CloudFlare DNS Record"
+  include_role:
+    name: cloudflare-dns
+  vars:
+    record: tdarr
+  when: cloudflare_enabled
+
+- name: Create htpasswd
+  htpasswd:
+    path: "/opt/nginx-proxy/htpasswd/{{ item }}.{{ user.domain }}"
+    name: "{{ user.name }}"
+    password: "{{ user.pass }}"
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: 0664
+  with_items:
+    - tdarrv2
+    
+- name: "Check if '/dev/dri' exists"
+  stat:
+    path: "/dev/dri"
+  register: dev_dri
+
+- name: Stop and remove any existing container
+  docker_container:
+    name: tdarrv2
+    state: absent
+
+- name: Create tdarr directories
+  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }}"
+  with_items:
+    - /opt/tdarrv2
+    - /opt/tdarrv2/server
+    - /opt/tdarrv2/config
+    - /opt/tdarrv2/logs
+    - "{{ (tdarrv2.transcode_dir|default('/tdarrv2_transcode_tmp_cache',true)) }}"
+
+- name: Create and start container
+  docker_container:
+    name: tdarrv2
+    image: ghcr.io/haveagitgat/tdarr
+    pull: yes
+    env:
+      TZ: "{{ tz }}"
+      PUID: "{{ uid }}"
+      PGID: "{{ gid }}"
+      VIRTUAL_HOST: "{{ (tdarrv2.direct_domain|default(false,true)) | ternary(user.domain + ',' + 'www.' + user.domain, tdarrv2.subdomain|default('code',true) + '.' + user.domain) }}" 
+      VIRTUAL_PORT: "8265"
+      LETSENCRYPT_HOST: "{{ (tdarrv2.direct_domain|default(false,true)) | ternary(user.domain + ',' + 'www.' + user.domain, tdarrv2.subdomain|default('code',true) + '.' + user.domain) }}"
+      LETSENCRYPT_EMAIL: "{{ user.email }}"
+      NVIDIA_DRIVER_CAPABILITIES: "{{ 'all' if gpu.nvidia | default(false) else omit }}"
+      NVIDIA_VISIBLE_DEVICES: "{{ 'all' if gpu.nvidia | default(false) else omit }}"
+    volumes:
+      - "/mnt/unionfs/Media:/media"
+      - "/mnt:/mnt"
+      - "/opt/tdarrv2/server:/app/server"
+      - "/opt/tdarrv2/config:/app/configs"
+      - "/opt/tdarrv2/logs:/app/logs"
+      - "/dev/shm:/dev/shm"
+      - "{{ (tdarrv2.transcode_dir|default('/tdarrv2_transcode_tmp_cache',true)) }}:/transcode_tmp_cache"
+    devices: "{{ '/dev/dri:/dev/dri' if (gpu.intel and dev_dri.stat.exists) | default(false) else omit }}"
+    labels:
+      "com.github.cloudbox.cloudbox_managed": "true"
+    networks:
+      - name: cloudbox
+        aliases:
+          - tdarrv2
+    purge_networks: yes
+    restart_policy: unless-stopped
+    state: started
+


### PR DESCRIPTION
- Added tdarrv2 web gui role
- Added tdarrv2 node role
- Updated readme to added tdarrv2. Need to set transcode cache directory
and possibly some other things to still make it work.
- Added settings in case you wanted to set subdomain to tdarr instead of
the default tdarrv2
- The tag to install is tdarrv2, which will install both roles. Could
change this later maybe if people wanted to spin up multiple nodes.
- This will automatically add the node to the web interface to use

Please review this template and edit it as appropriate.  It's not been provided as a thing to ignore.  If there are things that don't apply, remove them.  Don't just check boxes for the sake of checking boxes.  Remove this paragraph and the related thing below.

# Description

Updated tdarr from v1 to tdarrv2 and make it work

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] I have been using this for a while to update and maintain tdarrv2
- [ ] Initially I tested by destroying the service and configs and recreating. Although, I had to clean some stuff up, so someone else may want to test a clean install. This is only partially tested

# New Role Checklist:

- [X] I have reviewed the [Contribute page in the wiki](https://github.com/Cloudbox/Community/wiki/Contribute)
- [X] I have updated the header in any files I may have used as templates with my own information
- [X] I have added my new role to `[COMMUNITY REPO ROOT]/.github/workflows/ci.yml` --- Seems like this automatic now and not needed?
- [X] I have added my new role to `community.yml`
- [X] I have verified that any Docker images used are current and supported.
- [X] I have made corresponding changes to the documentation

