### PR TITLE
Modify postgres role to be more customizable

### DIFF
--- a/defaults/settings.yml.default
+++ b/defaults/settings.yml.default
@@ -87,6 +87,9 @@ plex_auto_collections:
   state: present 
 plex_meta_manager:
   time: 03:00
+postgres:
+  published_ports:
+    - 127.0.0.1:5432:5432
 qbittorrentvpn:
   vpn_endpoint: netherlands.ovpn
   vpn_user: your_vpn_username

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -30,13 +30,15 @@
       PUID: "{{ uid }}"
       PGID: "{{ gid }}"
       LOG_LEVEL: DEBUG
-      POSTGRES_PASSWORD: mysecretpassword
+      POSTGRES_USER: "{{ postgres.user }}"
+      POSTGRES_PASSWORD: "{{ postgres.password }}"
     volumes:
       - /opt/postgres/data:/var/lib/postgresql/data
     labels:
       "com.github.cloudbox.cloudbox_managed": "true"
     networks:
       - name: cloudbox
+    published_ports: "{{ postgres.published_ports|default('127.0.0.1:5432:5432',true) }}"
     purge_networks: yes
     restart_policy: unless-stopped
     state: started


### PR DESCRIPTION
Currently, you can't open the port for postgres to allow ansible to
interact and run queries from outside the container. This will open the
port to localhost only and allow you to directly communicate with the
postgres intance. This is needed for another PR, so we can run a query
against the instance.

Also, added username and password variables, so this can be added into
the accounts.yml

Please review this template and edit it as appropriate.  It's not been provided as a thing to ignore.  If there are things that don't apply, remove them.  Don't just check boxes for the sake of checking boxes.  Remove this paragraph and the related thing below.

# Description

Please see commit

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Added `postgres.user` and `postgres.password` to accounts.yml
- [X] Ran `ss -nltup` to ensure that its only listening on port 5432 on localhost
- [X] Ran `nc -zv mydomain 5432` from an external box to ensure we can't hit that port
- [X] Changed config to 0.0.0.0:5432:5432 and ran the above scripts. Found that *:5432 was now listening and that the port was open externally, which is expected.

# New Role Checklist:

- [X] I have reviewed the [Contribute page in the wiki](https://github.com/Cloudbox/Community/wiki/Contribute)
- [X] I have updated the header in any files I may have used as templates with my own information
- [X] I have added my new role to `[COMMUNITY REPO ROOT]/.github/workflows/ci.yml`
- [X] I have added my new role to `community.yml`
- [X] I have verified that any Docker images used are current and supported.
- [X] I have made corresponding changes to the documentation

