### PR TITLE
Set balance and scrub mountpoints to 'auto'

### DIFF
--- a/roles/btrfsmaintenance/tasks/main.yml
+++ b/roles/btrfsmaintenance/tasks/main.yml
@@ -41,9 +41,13 @@
   - name: "Change mountpoints to 'auto'"
     lineinfile:
       path: "/opt/btrfsmaintenance/sysconfig.btrfsmaintenance"
-      regexp: '^BTRFS_TRIM_MOUNTPOINTS\s?='
-      line: 'BTRFS_TRIM_MOUNTPOINTS="auto"'
+      regexp: '^{{ item }}\s?='
+      line: '{{ item }}="auto"'
       state: present
+    loop:
+      - BTRFS_TRIM_MOUNTPOINTS
+      - BTRFS_BALANCE_MOUNTPOINTS
+      - BTRFS_SCRUB_MOUNTPOINTS
 
   - name: "Execute dist-install.sh"
     become: yes


### PR DESCRIPTION
# Description

By default, the BTRFS_BALANCE_MOUNTPOINTS and BTRFS_SCRUB_MOUNTPOINTS are set to `/` so the role won't have any effect on a system with just `/opt` as btrfs. By setting the mount points to 'auto', the role will work with btrfs partitions other than `/`.

# How Has This Been Tested?

Tested the same changes on Saltbox. Adding here because this is where the role originated. FWIW, I was the person that first brought up btrfsmaintenance in the CB Discord.
