### PR TITLE
Use ffmpeg extractor on navidrome

### DIFF
--- a/roles/navidrome/tasks/main.yml
+++ b/roles/navidrome/tasks/main.yml
@@ -39,6 +39,7 @@
           VIRTUAL_PORT: "4533"
           LETSENCRYPT_HOST: "navidrome.{{ user.domain }}"
           LETSENCRYPT_EMAIL: "{{ user.email }}"
+          ND_SCANNER_EXTRACTOR: "ffmpeg"
         volumes:
           - "{{ navidrome.musicfolder }}:/music"
           - "/opt/navidrome:/data"


### PR DESCRIPTION
# Description

The default extractor, taglib, doesn't seem to work with the default setup and report errors when trying to read metadata, causing all artists and albums to be classified as [Various Artists].

Using ffmpeg works just fine.

# How Has This Been Tested?

- [ ] You can reproduce the bug by running with the taglib extractor, and read the logs with `docker logs navidrome`. If you see `time="2022-07-05T18:15:37Z" level=warning msg="Error reading metadata from file. Skipping" error="cannot process /music/XXX/XXX/XXX.flac" filePath="/music/XXX/XXX/XXX.flac"` or an equivalent, you've reproduced the bug.
- [ ] Once reproduced, change the default extractor, rerun the tag to recreate the container, you'll see that it scans just fine (you may need to run a full scan using the activity tab in the webui at the top left)
