### PR TITLE
Added a role for Audiobookshelf, a tool for selh-hosting audiobook an…

### DIFF
--- a/community.yml
+++ b/community.yml
@@ -20,6 +20,7 @@
     - { role: apprise, tags: ['apprise'] }
     - { role: archivebox, tags: ['archivebox'] }
     - { role: asshama, tags: ['asshama'] }
+    - { role: audiobookshelf, tags: ['audiobookshelf']}
     - { role: autoscan, tags: ['autoscan'] }
     - { role: bazarrx, tags: ['bazarrx'] }
     - { role: beets, tags: ['beets'] }

--- a/roles/audiobookshelf/main.yml
+++ b/roles/audiobookshelf/main.yml
@@ -1,0 +1,58 @@
+#########################################################################
+# Title:            Community: Audiobookshelf                           #
+# Author(s):        astrodad                                            #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image(s):  ghcr.io/advplyr/audiobookshelf                      #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: "Setting CloudFlare DNS Record"
+  include_role:
+    name: cloudflare-dns
+  vars:
+    record: audiobookshelf
+  when: cloudflare_enabled
+
+- name: Stop and remove any existing container
+  docker_container:
+    name: audiobookshelf
+    state: absent
+
+- name: Create audiobookshelf directories
+  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }}"
+  with_items:
+    - /opt/audiobookshelf
+    - /opt/audiobookshelf/metadata
+
+- name: Create and start container
+  docker_container:
+    name: audiobookshelf
+    image: ghcr.io/advplyr/audiobookshelf:latest
+    pull: yes
+    env:
+      PUID: "{{ uid }}"
+      PGID: "{{ gid }}"
+      TZ: "{{ tz }}"
+      VIRTUAL_HOST: "audiobookshelf.{{ user.domain }}"
+      VIRTUAL_PORT: "13378"
+      LETSENCRYPT_HOST: "audiobookshelf.{{ user.domain }}"
+      LETSENCRYPT_EMAIL: "{{ user.email }}"
+    volumes:
+      - "/opt/audiobookshelf:/config"
+      - "/opt/audiobookshelf/metadata:/metadata"
+      - "/mnt/unionfs/Media/Audiobooks:/audiobooks"
+      - "/mnt/unionfs/Media/Podcasts:/podcasts"
+      - "/mnt:/mnt"
+
+    labels:
+      "com.github.cloudbox.cloudbox_managed": "true"
+    networks:
+      - name: cloudbox
+        aliases:
+          - audiobookshelf
+    purge_networks: yes
+    restart_policy: unless-stopped
+    state: started


### PR DESCRIPTION
# Description

Added a role for Audiobookshelf, a tool for selh-hosting audiobook and podcast streaming. You can find the info for Audiobookshelf at [https://www.audiobookshelf.org](https://www.audiobookshelf.org)

# How Has This Been Tested?

I used this on my own Cloudbox server and used it twice to install/remove the docker container.


# New Role Checklist:

- [X] I have reviewed the [Contribute page in the wiki](https://github.com/Cloudbox/Community/wiki/Contribute)
- [X] I have updated the header in any files I may have used as templates with my own information
- [--] I have added my new role to `[COMMUNITY REPO ROOT]/.github/workflows/ci.yml` 

It does not appear that any other roles are adding their info here. I don't think it applies. 

- [X] I have added my new role to `community.yml`
- [X] I have verified that any Docker images used are current and supported.
- [X] I have made corresponding changes to the documentation

