### PR TITLE
Update Calibre role w/ security_opts

### DIFF
--- a/roles/calibre/tasks/main.yml
+++ b/roles/calibre/tasks/main.yml
@@ -62,6 +62,8 @@
       - name: cloudbox
         aliases:
           - calibre
+    security_opts:
+          - seccomp:unconfined #optional          
     exposed_ports:
       - 8080
       - 8081


### PR DESCRIPTION
Please review this template and edit it as appropriate.  It's not been provided as a thing to ignore.  If there are things that don't apply, remove them.  Don't just check boxes for the sake of checking boxes.  Remove this paragraph and the related thing below.

# Description

Calibre does not boot without this extra parameter. This is explicity provided on calibre's readme

# How Has This Been Tested?

With and without this paramater for comparison. 
