### PR TITLE
Added jellyseerr

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This is a partial list of roles available via Community; once the repo is instal
 - **invoiceninja**
 - **[jdownloader2](../../wiki/JDownloader2)** - [JDownloader2](https://github.com/jlesage/docker-jdownloader-2) Self-hosted free, open-source download management tool with GUI website frontend.
 - **jellyfin** - [jellyfin](https://github.com/jellyfin/jellyfin) emby fork
+- **jellyseerr** - [jellyseerr](https://github.com/Fallenbagel/jellyseerr) overseerr fork
 - **kitana** - A responsive Plex plugin web frontend
 - **[komga](https://komga.org/)** - comics server and online reader (similar to ubooquity, but actively developed as of today); to get the original admin username and passowrd, type docker logs komga and follow the [help](https://komga.org/installation/user-accounts.html#automatic-mode-default)
 - **lazylibrarian** - (uses calibre-rdp db)

--- a/community.yml
+++ b/community.yml
@@ -67,6 +67,7 @@
     - { role: influxdb, tags: ['influxdb'] }
     - { role: invoiceninja, tags: ['invoiceninja'] }
     - { role: jellyfin, tags: ['jellyfin'] }
+    - { role: jellyseerr, tags: ['jellyseerr'] }
     - { role: jfa-go, tags: ['jfa-go', 'jellyfinaccounts', 'jellyfinaccountsgo'] }
     - { role: jirafeau, tags: ['jirafeau'] }
     - { role: kcptun-client, tags: ['kcptun-client'] }

--- a/roles/jellyseerr/tasks/main.yml
+++ b/roles/jellyseerr/tasks/main.yml
@@ -1,0 +1,64 @@
+#########################################################################
+# Title:            Community: jellyseerr                               #
+# Author(s):        JackDallas, Thundernerd                             #
+# URL:              https://github.com/Cloudbox/Community               #
+# Docker Image(s):  fallenbagel/jellyseerr                              #
+# --                                                                    #
+#         Part of the Cloudbox project: https://cloudbox.works          #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+
+- name: "Set DNS Record on CloudFlare"
+  include_role:
+    name: cloudflare-dns
+  vars:
+    record: "{{ jellyseerr.subdomain|default('jellyseerr',true) }}"
+  when: (cloudflare_enabled) and not (jellyseerr.direct_domain|default(false,true))
+
+- name: "Set DNS Record on CloudFlare"
+  include_role:
+    name: cloudflare-dns
+  vars:
+    record: "{{ item }}"
+  with_items:
+    - "{{ user.domain }}"
+    - "www"
+  when: (cloudflare_enabled) and (jellyseerr.direct_domain|default(false,true))
+
+- name: Stop and remove any existing container
+  docker_container:
+    name: jellyseerr
+    state: absent
+
+- name: Create jellyseerr directories
+  file: 'path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }}'
+  with_items:
+    - /opt/jellyseerr
+
+- name: Create and start container
+  docker_container:
+    name: jellyseerr
+    image: "fallenbagel/jellyseerr"
+    pull: yes
+    published_ports:
+      - "5055:5055"
+    user: "{{ uid }}:{{ gid }}"
+    env:
+      VIRTUAL_HOST: "jellyseerr.{{ user.domain }}" 
+      VIRTUAL_PORT: "5055"
+      LETSENCRYPT_HOST: "jellyseerr.{{ user.domain }}"
+      LETSENCRYPT_EMAIL: "{{ user.email }}"
+      TZ: "{{ tz }}"
+    volumes:
+      - "/opt/jellyseerr:/app/config"
+    labels:
+      "com.github.cloudbox.cloudbox_managed": "true"
+    networks:
+      - name: cloudbox
+        aliases:
+          - jellyseerr
+    purge_networks: yes
+    restart_policy: unless-stopped
+    state: started


### PR DESCRIPTION
# Description

Adds a role for [Jellyseerr](https://github.com/Fallenbagel/jellyseerr), a overseerr fork that supports Jellyfin

# How Has This Been Tested?

- [x] Clean install
- [x] Reinstall

# New Role Checklist:

- [x] I have reviewed the [Contribute page in the wiki](https://github.com/Cloudbox/Community/wiki/Contribute)
- [x] I have updated the header in any files I may have used as templates with my own information
- [ ] I have added my new role to `[COMMUNITY REPO ROOT]/.github/workflows/ci.yml`
- [x] I have added my new role to `community.yml`
- [x] I have verified that any Docker images used are current and supported.
- [x] I have made corresponding changes to the documentation
